### PR TITLE
fix: sentry flags if feed is empty

### DIFF
--- a/src/discord_webhook.rs
+++ b/src/discord_webhook.rs
@@ -92,9 +92,9 @@ impl DiscordWebhook {
 
         loop {
             attempts += 1;
-            // codeql[rust/cleartext-transmission]
             let response = self
                 .client
+                // codeql[rust/cleartext-transmission]
                 .post(self.url.expose_secret())
                 .json(payload)
                 .send()

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,14 +30,49 @@ pub enum Error {
     Custom(String),
 }
 
+fn is_expected_feed_parse_message(message: &str) -> bool {
+    message
+        .to_ascii_lowercase()
+        .contains("did not begin with an rss tag")
+}
+
 impl Error {
     pub fn custom<T: ToString>(msg: T) -> Self {
         Self::Custom(msg.to_string())
+    }
+
+    pub fn is_expected_feed_parse_error(&self) -> bool {
+        match self {
+            Self::Rss(err) => is_expected_feed_parse_message(&err.to_string()),
+            _ => false,
+        }
     }
 }
 
 impl From<&str> for Error {
     fn from(err: &str) -> Self {
         Self::Custom(err.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Error, is_expected_feed_parse_message};
+
+    #[test]
+    fn identifies_expected_rss_parse_message() {
+        assert!(is_expected_feed_parse_message(
+            "the input did not begin with an rss tag"
+        ));
+    }
+
+    #[test]
+    fn ignores_unrelated_rss_parse_message() {
+        assert!(!is_expected_feed_parse_message("invalid date"));
+    }
+
+    #[test]
+    fn does_not_mark_custom_error_as_expected_parse_error() {
+        assert!(!Error::custom("boom").is_expected_feed_parse_error());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,10 +95,18 @@ impl FeedChecker {
                 }
             }
             Err(e) => {
-                error!("Error fetching feed for {}: {}", feed.name(), e);
-                metrics::get_feed_fetch_errors()
-                    .with_label_values(&[feed.name()])
-                    .inc();
+                if e.is_expected_feed_parse_error() {
+                    warn!(
+                        "Skipping malformed feed payload for {}: {}",
+                        feed.name(),
+                        e
+                    );
+                } else {
+                    error!("Error fetching feed for {}: {}", feed.name(), e);
+                    metrics::get_feed_fetch_errors()
+                        .with_label_values(&[feed.name()])
+                        .inc();
+                }
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,11 +96,7 @@ impl FeedChecker {
             }
             Err(e) => {
                 if e.is_expected_feed_parse_error() {
-                    warn!(
-                        "Skipping malformed feed payload for {}: {}",
-                        feed.name(),
-                        e
-                    );
+                    warn!("Skipping malformed feed payload for {}: {}", feed.name(), e);
                 } else {
                     error!("Error fetching feed for {}: {}", feed.name(), e);
                     metrics::get_feed_fetch_errors()


### PR DESCRIPTION
The netcup feed returns an invalid rss feed if it is empty