### PR TITLE
fix: repair release manifest step and update rss + sentry

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -182,11 +182,17 @@ jobs:
       - name: Create multi-platform manifest list and push
         working-directory: /tmp/digests
         run: |
+          set -euo pipefail
+
+          # The bake file nests tags under a target, the metadata JSON exposes
+          # them at the top level. This step reads the latter.
+          tag_args=$(jq -cer '.tags | map("-t " + .) | join(" ")' <<< "${DOCKER_METADATA_OUTPUT_JSON}")
+
           # Word splitting is intentional: both substitutions expand to a list of
           # separate arguments (-t <tag> ... and one reference per digest file).
-          # shellcheck disable=SC2046
+          # shellcheck disable=SC2046,SC2086
           docker buildx imagetools create \
-            $(jq -cr '.target."docker-metadata-action".tags | map("-t " + .) | join(" ")' <<< "${DOCKER_METADATA_OUTPUT_JSON}") \
+            ${tag_args} \
             $(printf "${DOCKER_REPO}@sha256:%s " *)
 
       - name: Resolve pushed image digest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1701,7 +1701,6 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -2009,9 +2008,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "sentry"
-version = "0.48.5"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d631477761f57c76148456e55e80e9a479ff3fa4c65b2b4a0c3acf1167fd4638"
+checksum = "63207365db50cb817402f0ec8097d6dad3d644ef3fffd6ba30c75b3077e514da"
 dependencies = [
  "cfg_aliases",
  "httpdate",
@@ -2028,9 +2027,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-anyhow"
-version = "0.48.5"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f73466a403f4da78c7e576049d6044b31d2b16dfcc26b51705f318ed74b804"
+checksum = "6265521f1b724f709bc07747ecb01c5289b974cb70b348026df01780280fc136"
 dependencies = [
  "anyhow",
  "sentry-backtrace",
@@ -2039,9 +2038,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.48.5"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "448b0981fbde6cdc9eb087ba3dc01035a253fef9a0d9e79aaf198fc26acb2e64"
+checksum = "e3bcc2497c2327998146207b7600599ef7592233920f4d4e1d41ddeeba0e4210"
 dependencies = [
  "backtrace",
  "regex",
@@ -2050,9 +2049,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.48.5"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecf0b1a4a4e9ec88395b52e6fa4868b95564c1fa96b26a0606f5f6288a0f7149"
+checksum = "48759bc392fb5e3b36b4efcb485f51074c0ba8479711cd5c8cf79e86f9f75d41"
 dependencies = [
  "rand",
  "sentry-types",
@@ -2063,9 +2062,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.48.5"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81d7749c57fc78ed52134889e8121da874065bc40da788d5798cce0f8c19f15"
+checksum = "0a5bd325059b70b21ca6e42b0f2409821272dddc1cf37923de37269af55389b5"
 dependencies = [
  "findshlibs",
  "sentry-core",
@@ -2073,9 +2072,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.48.5"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58d26379236c4ef97eaf081bca3c7bf0ef6f06b3aa881eca2ee8e8dbc923e5b8"
+checksum = "8aa7d8e0db4cccddbac01ddabd5344ad03b7c2f954b3ff850cecb1d9cf5d4758"
 dependencies = [
  "bitflags",
  "sentry-backtrace",
@@ -2086,9 +2085,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.48.5"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2239099d47e76857b0825a182ecdb90159add7aa1097b60247c6e7ca6bf49c6a"
+checksum = "fab146d15a30ab4897a95fd15d6a038b8d7fbf2661c5f8b13738ce8df7a095b7"
 dependencies = [
  "debugid",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "atom_syndication"
-version = "0.12.8"
+version = "0.12.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39d8b8ef99e33deb2a51504888222225797f48bace2f0cab01975746a39c05bb"
+checksum = "d48d93a31c932d58b9fd68664a904ae5b74bea37f06c5f68d5bec92f0cdd106d"
 dependencies = [
  "chrono",
  "derive_builder",
@@ -1538,9 +1538,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "encoding_rs",
  "memchr",
@@ -1792,9 +1792,9 @@ dependencies = [
 
 [[package]]
 name = "rss"
-version = "2.0.13"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0e38781082c53bdde56e6081698c06831f69a27eac2593ed6b6cb2511424ad5"
+checksum = "dc13570823abc675c60d7837f1fe7daaf18dd181a3cacb3c6ba7a062eef581c0"
 dependencies = [
  "atom_syndication",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ name = "netcup-offer-bot"
 anyhow = { version = "1.0.100", features = ["backtrace"] }
 thiserror = "2.0.18"
 backtrace = "0.3.76"
-sentry = { version = "0.48.0", default-features = false, features = ["anyhow", "debug-images", "reqwest", "rustls", "backtrace", "tracing"] }
+sentry = { version = "0.49.1", default-features = false, features = ["anyhow", "debug-images", "reqwest", "rustls", "backtrace", "tracing"] }
 chrono = { version = "0.4.43", default-features = false, features = ["clock", "std", "wasmbind", "serde"] }
 rss = { version = "2.0.12", features = ["validation"] }
 reqwest = { version = "0.13.1", default-features = false, features = ["json", "rustls", "stream", "gzip"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,4 +40,10 @@ wiremock = "=0.6.5"
 [profile.release]
 lto = true
 codegen-units = 1
-debug = true
+# Sentry only needs function names, file names and line numbers to symbolicate
+# stack frames, all of which "limited" keeps. Full debug info additionally emits
+# a DW_TAG_variable for every static; under fat LTO the statics themselves are
+# constant-folded away, leaving .debug_info/.debug_aranges relocations against
+# symbols no object file defines and an "undefined reference to
+# `encoding_rs::UTF_8'" failure when ld links the musl binary.
+debug = "limited"

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,15 +65,14 @@ fn setup_sentry(dns: Option<String>) -> Option<ClientInitGuard> {
     };
 
     // Sentry innit
-    Some(sentry::init((
-        dns,
-        sentry::ClientOptions {
-            release: sentry::release_name!(),
-            traces_sample_rate: 0.2,
-            attach_stacktrace: true,
-            ..Default::default()
-        },
-    )))
+    let mut options = sentry::ClientOptions::new()
+        .traces_sample_rate(0.2)
+        .attach_stacktrace(true);
+    if let Some(release) = sentry::release_name!() {
+        options = options.release(release);
+    }
+
+    Some(sentry::init((dns, options)))
 }
 
 fn setup_metrics(socket: &SocketAddr) -> Result<()> {


### PR DESCRIPTION
## Release CI fix

The `Docker Release` job of [run 30834109830](https://github.com/TimSchoenle/netcup-offer-bot/actions/runs/30834109830/job/91757904048) failed with:

```
jq: error (at <stdin>:1): Cannot iterate over null (null)
ERROR: can't push with no tags specified, please set --tag or --dry-run
```

`Create multi-platform manifest list and push` queried `.target."docker-metadata-action".tags` — the *bake file* layout — against `DOCKER_METADATA_OUTPUT_JSON`, where `docker/metadata-action` puts tags at the top level:

```json
{"tags":["…/netcup-offer-bot:v1.5.23"],"tag-names":["v1.5.23"],"labels":{…},"annotations":[…]}
```

jq returned `null`, the tag list expanded to nothing, and `buildx imagetools create` refused to push. The v1.5.23 per-arch images were pushed by digest but never got a tagged multi-platform index, which also blocked `Helm Release`.

Fixed by querying `.tags`, plus `jq -e` and `set -euo pipefail` so an empty tag list fails at the jq call instead of surfacing as a confusing buildx error.

## Dependency updates

| Crate | From | To | Supersedes |
|---|---|---|---|
| `rss` | 2.0.13 | 2.1.0 | #383 |
| `sentry` | 0.48.5 | 0.49.1 | #443 |

`rss` is a lockfile-only bump; the existing `2.0.12` requirement already covers it.

`sentry` 0.49 is a breaking release. `ClientOptions` is now `#[non_exhaustive]` and the public `traces_sample_rate` field is gone, so `setup_sentry` moves to the builder-style setters. `release_name!()` returns an `Option` while `release()` takes a bare value, so the release name is only applied when one resolves — same behaviour as before. The newly default-on `logs`/`metrics` features don't apply here because the dependency is declared with `default-features = false`.

#443 targeted 0.49.0 with 0.49.1 pending; this goes straight to 0.49.1.

## Verification

`cargo build`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check` and `cargo test` (30 tests) all pass locally. The workflow change can only be confirmed by the next release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## amd64 Docker build fix

The `Docker Build and Test (amd64)` job failed on this branch (arm64 passed):

```
ld: netcup_offer_bot-...cgu.0.rcgu.o:(.debug_info+0x3ddc4c):
    undefined reference to `encoding_rs::UTF_8'
```

Not caused by the sentry change — #383, which only bumps `rss` in the lockfile, has been failing the same way since Aug 3. `rss` 2.1.0 pulls `quick-xml` 0.39 → 0.41, and its reworked encoding module is what tips the release link over.

Root cause: `[profile.release] debug = true` emits a `DW_TAG_variable` for every static. Under `lto = true` the `encoding_rs::UTF_8` / `UTF_16BE` / `UTF_16LE` statics get constant-folded away, so the resulting `.debug_info` and `.debug_aranges` relocations point at symbols no object file defines, and GNU ld rejects the link. aarch64 codegens differently and never hit it.

Fixed by dropping the release profile to `debug = "limited"`, which omits variable-level DWARF but keeps the symbol table, line tables and unwind info — everything Sentry uses to symbolicate frames.

Verified by reproducing and fixing against the real amd64 image locally:

- before the change: same `undefined reference to encoding_rs::UTF_8` link failure
- after: build succeeds
- `sentry-cli debug-files check` on the pre-strip binary reports `symtab, debug, unwind` and `Usable: yes`
- the line table still resolves addresses to source files and line numbers (~693k rows), e.g. `feed.rs 30 0x83e37`
