### PR TITLE
feat!: load configuration from files via terrace-config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -92,3 +92,6 @@ fabric.properties
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
+
+# Local configuration layer, which may hold the real Discord webhook. Never in a build context.
+config.toml

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,7 @@ fabric.properties
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
+
+# Local configuration layer: `./config.toml` is the default TOML source, so a working copy of
+# it holds the real Discord webhook.
+config.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,12 +42,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
-name = "arraydeque"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
-
-[[package]]
 name = "ascii"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,6 +90,15 @@ dependencies = [
  "derive_builder",
  "diligent-date-parser",
  "quick-xml",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -159,15 +162,18 @@ name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
-dependencies = [
- "serde_core",
-]
 
 [[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "bytes"
@@ -267,55 +273,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
-name = "config"
-version = "0.15.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b85f248a4de22d204ceabc6299d89d2c70fbd7f09fea53c06c852369652d8139"
-dependencies = [
- "async-trait",
- "convert_case",
- "json5",
- "pathdiff",
- "ron",
- "rust-ini",
- "serde-untagged",
- "serde_core",
- "serde_json",
- "toml",
- "winnow",
- "yaml-rust2",
-]
-
-[[package]]
-name = "const-random"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
-dependencies = [
- "const-random-macro",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "tiny-keccak",
-]
-
-[[package]]
-name = "convert_case"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,12 +305,6 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "darling"
@@ -476,15 +427,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dlv-list"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
-dependencies = [
- "const-random",
-]
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,17 +448,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "erased-serde"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
-dependencies = [
- "serde",
- "serde_core",
- "typeid",
-]
-
-[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +462,22 @@ name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic",
+ "parking_lot",
+ "pear",
+ "serde",
+ "tempfile",
+ "toml",
+ "uncased",
+ "version_check",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -565,12 +512,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -741,33 +682,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
-name = "hashlink"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
-dependencies = [
- "hashbrown 0.16.1",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -1026,8 +943,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
+ "hashbrown",
 ]
+
+[[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "ipnet"
@@ -1109,17 +1032,6 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "json5"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
-dependencies = [
- "pest",
- "pest_derive",
- "serde",
 ]
 
 [[package]]
@@ -1219,7 +1131,7 @@ dependencies = [
  "anyhow",
  "backtrace",
  "chrono",
- "config",
+ "figment",
  "prometheus 0.14.0",
  "prometheus_exporter",
  "reqwest",
@@ -1231,8 +1143,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_test",
- "temp-env",
  "tempfile",
+ "terrace-config",
  "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
@@ -1297,16 +1209,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
-name = "ordered-multimap"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
-dependencies = [
- "dlv-list",
- "hashbrown 0.14.5",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1330,58 +1232,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "pathdiff"
-version = "0.2.3"
+name = "pear"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "pest"
-version = "2.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -1426,6 +1303,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -1782,20 +1672,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ron"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81116b9531d61eabc41aeb228e4b6b2435bcca3233b98cf3b3077d4e6e9debb3"
-dependencies = [
- "bitflags",
- "once_cell",
- "serde",
- "serde_derive",
- "typeid",
- "unicode-ident",
-]
-
-[[package]]
 name = "rss"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1807,16 +1683,6 @@ dependencies = [
  "mime",
  "quick-xml",
  "url",
-]
-
-[[package]]
-name = "rust-ini"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
-dependencies = [
- "cfg-if",
- "ordered-multimap",
 ]
 
 [[package]]
@@ -2117,18 +1983,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-untagged"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058"
-dependencies = [
- "erased-serde",
- "serde",
- "serde_core",
- "typeid",
-]
-
-[[package]]
 name = "serde_core"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2163,11 +2017,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.1"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
- "serde_core",
+ "serde",
 ]
 
 [[package]]
@@ -2309,15 +2163,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "temp-env"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
-dependencies = [
- "parking_lot",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2328,6 +2173,16 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terrace-config"
+version = "0.2.0"
+source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.2.0#46d924c25af6a0e67f657686f996539482e8abe3"
+dependencies = [
+ "figment",
+ "serde",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -2407,15 +2262,6 @@ checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -2521,34 +2367,44 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
- "serde_core",
+ "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_parser",
- "winnow",
+ "toml_edit",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
- "serde_core",
+ "serde",
 ]
 
 [[package]]
-name = "toml_parser"
-version = "1.1.3+spec-1.1.0"
+name = "toml_edit"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -2664,28 +2520,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "typeid"
-version = "1.0.3"
+name = "uncased"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "untrusted"
@@ -2762,6 +2609,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -3086,9 +2939,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.4"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
@@ -3129,15 +2982,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
-name = "yaml-rust2"
-version = "0.11.0"
+name = "yansi"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
-dependencies = [
- "arraydeque",
- "encoding_rs",
- "hashlink",
-]
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,17 @@ serde_json = "1.0.149"
 prometheus = { version = "0.14.0", features = ["process"] }
 prometheus_exporter = "0.8.5"
 secrecy = { version = "0.10.3", features = ["serde"] }
-config = "0.15.19"
+# The layered loader: struct defaults, TOML, prefixed environment, a secrets directory and
+# `_FILE` indirection, so a mounted Kubernetes `Secret` can supply the webhook URL instead of an
+# environment variable. `loader` only — the `reload` supervisor would link notify and is not
+# usable here while the Prometheus exporter binds its socket process-globally.
+# Pinned by tag, not branch: `cargo update` cannot then move the dependency silently.
+terrace-config = { git = "https://github.com/TimSchoenle/terrace-config", tag = "v0.2.0", default-features = false, features = ["loader"] }
 
 [dev-dependencies]
-temp-env = "=0.3.6"
+# `figment::Jail` gives the config tests a scratch directory and an environment it restores
+# afterwards. The same figment `terrace-config` resolves, plus its `test` feature.
+figment = { version = "=0.10.19", features = ["test"] }
 tempfile = "=3.27.0"
 serde_test = "=1.0.177"
 wiremock = "=0.6.5"

--- a/README.md
+++ b/README.md
@@ -39,23 +39,95 @@ the matching architecture automatically, so the commands below are identical on 
 ```shell
   docker run \
     --name netcup-offer-bot \
-    -e WEB_HOOK="https://discord.com/api/webhooks/..." \
-    -e CHECK_INTERVAL="180" \
+    -e NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL="https://discord.com/api/webhooks/..." \
+    -e NETCUP_OFFER_BOT_FEED__CHECK_INTERVAL_SECS="180" \
     -v netcup-offer-bot-data:/app/data \
     -d \
     timmi6790/netcup-offer-bot:latest
   ```
 
-#### Environment variables
+## Configuration
 
-| Environment    	  | Required 	  | Description                         	                                             |
-|-------------------|-------------|-----------------------------------------------------------------------------------|
-| SENTRY_DSN     	  | 	           | Sentry dns                          	                                             |
-| WEB_HOOK       	  | X         	 | Discord webhook                     	                                             |
-| CHECK_INTERVAL 	  | X         	 | RSS feed check interval in seconds 	                                              |
-| METRIC_IP       	 | 	           | Prometheus exporter ip [Default: 0.0.0.0]                           	             |
-| METRIC_PORT     	 | 	           | Prometheus exporter port [Default: 9184]                            	             |
-| LOG_LEVEL  	      | 	           | Log level [FATAL, ERROR, WARN, INFO, DEBUG, TRACE, ALL]                         	 |
+Configuration is layered by [terrace-config](https://github.com/TimSchoenle/terrace-config), so the
+Discord webhook can arrive as a mounted file rather than as an environment variable that shows up
+in `docker inspect` and in the environment of every child process.
+
+Lowest precedence first:
+
+1. The defaults compiled into the config structs.
+2. TOML at `$NETCUP_OFFER_BOT_CONFIG`, defaulting to `./config.toml` — a file, or every `*.toml`
+   directly inside it when it names a directory, merged in file-name order. A missing file is not
+   an error.
+3. `NETCUP_OFFER_BOT_`-prefixed environment variables.
+4. Every key-named file in `$NETCUP_OFFER_BOT_SECRETS_DIR`.
+5. `NETCUP_OFFER_BOT_<KEY>_FILE=/path`, which reads `<KEY>` from that path.
+
+**Layers 3, 4 and 5 are mutually exclusive per key.** A key supplied by two of them fails the boot
+naming the key and both sources, rather than being resolved by precedence: a stale environment
+variable shadowing a webhook that has since been rotated would otherwise keep the bot posting to
+the old one, and the discrepancy would surface long after the deploy that caused it.
+
+**Nesting is `__` (two underscores)** — a single underscore is part of a field name. Case is
+folded, so `discord.webhook_url` is `NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL` as a variable and
+`discord__webhook_url` as a file name.
+
+#### Keys
+
+| Key                                        | Required | Default     | Description                                              |
+|--------------------------------------------|----------|-------------|----------------------------------------------------------|
+| `NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL`    | X        |             | Discord webhook the offers are posted to                 |
+| `NETCUP_OFFER_BOT_FEED__CHECK_INTERVAL_SECS` | X      |             | Seconds between two RSS feed checks                      |
+| `NETCUP_OFFER_BOT_METRICS__IP`             |          | `127.0.0.1` | Prometheus exporter address                              |
+| `NETCUP_OFFER_BOT_METRICS__PORT`           |          | `9184`      | Prometheus exporter port                                 |
+| `NETCUP_OFFER_BOT_TELEMETRY__LOG_LEVEL`    |          | `INFO`      | One of `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`         |
+| `NETCUP_OFFER_BOT_TELEMETRY__SENTRY_DSN`   |          |             | Sentry DSN; unset disables Sentry entirely               |
+
+Two further variables are read to decide what the layers *are*, and so cannot themselves be
+supplied by a layer:
+
+| Key                             | Default       | Description                                                        |
+|---------------------------------|---------------|--------------------------------------------------------------------|
+| `NETCUP_OFFER_BOT_CONFIG`       | `config.toml` | The TOML layer: a file, or a directory whose `*.toml` are merged   |
+| `NETCUP_OFFER_BOT_SECRETS_DIR`  |               | Directory of key-named files. Unset disables the layer; set but unreadable fails the boot |
+
+#### `config.toml`
+
+```toml
+[discord]
+webhook_url = "https://discord.com/api/webhooks/..."
+
+[feed]
+check_interval_secs = 180
+
+[metrics]
+ip = "0.0.0.0"
+port = 9184
+
+[telemetry]
+log_level = "INFO"
+```
+
+#### Secrets from files
+
+A Kubernetes `Secret` mounted as a volume, one file per key — the provider follows the `..data`
+indirection a projected volume uses, so the mount works as written:
+
+```shell
+  docker run \
+    --name netcup-offer-bot \
+    -e NETCUP_OFFER_BOT_SECRETS_DIR="/run/secrets" \
+    -e NETCUP_OFFER_BOT_FEED__CHECK_INTERVAL_SECS="180" \
+    -v ./webhook:/run/secrets/discord__webhook_url:ro \
+    -v netcup-offer-bot-data:/app/data \
+    -d \
+    timmi6790/netcup-offer-bot:latest
+  ```
+
+Or Docker's `_FILE` convention, for a single secret:
+
+```shell
+  -e NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL_FILE="/run/secrets/webhook"
+  ```
 
 ## License
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,194 +1,143 @@
-use crate::error::Error;
-use secrecy::SecretString;
-use std::net::SocketAddr;
+//! The typed configuration surface, and the loader every run boots through.
+//!
+//! The layering is [`terrace_config`]'s. Lowest precedence first: the `serde` defaults compiled
+//! into the structs below, TOML at `$NETCUP_OFFER_BOT_CONFIG` (default `./config.toml`, absent
+//! is not an error), `NETCUP_OFFER_BOT_`-prefixed `__`-nested environment variables, every
+//! key-named file in `$NETCUP_OFFER_BOT_SECRETS_DIR`, and `NETCUP_OFFER_BOT_<KEY>_FILE`
+//! indirection.
+//!
+//! The point of the last two is that the Discord webhook — the one credential this process
+//! holds — can arrive as a mounted Kubernetes `Secret` or a Docker secret file rather than as
+//! an environment variable that shows up in `docker inspect` and in every child process's
+//! environment.
+//!
+//! Every layer spells a field the same way: `__` separates nesting levels and case is folded,
+//! so `discord.webhook_url` is `NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL` as a variable and
+//! `discord__webhook_url` as a file name.
+
+mod loader;
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::str::FromStr;
 use std::time::Duration;
 
-const DEFAULT_METRIC_IP: &str = "127.0.0.1";
+use secrecy::SecretString;
+use serde::{Deserialize, Deserializer};
+use tracing::Level;
+
+pub use loader::ConfigError;
+
+const DEFAULT_METRIC_IP: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
 const DEFAULT_METRIC_PORT: u16 = 9184;
+const DEFAULT_LOG_LEVEL: Level = Level::INFO;
 
-#[derive(Debug, serde::Deserialize)]
-struct RawConfig {
-    web_hook: SecretString,
-    check_interval: u64,
-    metric_ip: Option<String>,
-    metric_port: Option<u16>,
-}
-
-#[derive(Debug)]
+/// Everything the process reads before it starts.
+#[derive(Debug, Deserialize)]
 pub struct Config {
-    pub discord_webhook_url: SecretString,
-    pub check_interval: Duration,
-    pub metric_socket: SocketAddr,
-}
-
-impl TryFrom<RawConfig> for Config {
-    type Error = crate::Error;
-
-    fn try_from(value: RawConfig) -> Result<Self, Self::Error> {
-        let check_interval = Duration::from_secs(value.check_interval);
-        let metric_ip = value
-            .metric_ip
-            .unwrap_or_else(|| DEFAULT_METRIC_IP.to_string());
-        let metric_port = value.metric_port.unwrap_or(DEFAULT_METRIC_PORT);
-        let metric_ip = match metric_ip.parse::<std::net::IpAddr>() {
-            Ok(ip) => ip,
-            Err(_) => {
-                return Err(Error::custom(format!(
-                    "Invalid metric ip address: {metric_ip}"
-                )));
-            }
-        };
-
-        let metric_socket = SocketAddr::new(metric_ip, metric_port);
-        Ok(Self {
-            discord_webhook_url: value.web_hook,
-            check_interval,
-            metric_socket,
-        })
-    }
+    pub discord: DiscordConfig,
+    pub feed: FeedConfig,
+    #[serde(default)]
+    pub metrics: MetricsConfig,
+    #[serde(default)]
+    pub telemetry: TelemetryConfig,
 }
 
 impl Config {
-    pub fn get_configurations() -> crate::Result<Self> {
-        config::Config::builder()
-            .add_source(config::Environment::default())
-            .build()
-            .map_err(|e| Error::custom(format!("Can't parse config: {e}")))?
-            .try_deserialize::<RawConfig>()
-            .map_err(|e| Error::custom(format!("Failed to deserialize configuration: {e}")))?
-            .try_into()
+    /// Load the configuration from every layer.
+    ///
+    /// # Errors
+    /// Returns [`ConfigError`] if a required value is missing, a value fails to parse, a
+    /// file-backed source cannot be read, or one key is supplied by more than one of the
+    /// environment, the secrets directory and `_FILE` indirection.
+    pub fn load() -> Result<Self, ConfigError> {
+        loader::load()
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use secrecy::ExposeSecret;
+/// Where new offers are announced.
+#[derive(Debug, Deserialize)]
+pub struct DiscordConfig {
+    /// The webhook to post to. Secret: it is a bearer credential — anyone holding it can post
+    /// to the channel — so it stays wrapped from the layer that read it to the request that
+    /// uses it.
+    pub webhook_url: SecretString,
+}
 
-    use super::*;
+/// How often the RSS feeds are polled.
+#[derive(Debug, Deserialize)]
+pub struct FeedConfig {
+    /// Seconds between two feed checks. Spelled in seconds rather than as a [`Duration`] so
+    /// the TOML and the environment layer agree on one representation.
+    check_interval_secs: u64,
+}
 
-    const ENV_WEB_HOOK: &str = "WEB_HOOK";
-    const ENV_CHECK_INTERVAL: &str = "CHECK_INTERVAL";
-    const ENV_METRIC_IP: &str = "METRIC_IP";
-    const ENV_METRIC_PORT: &str = "METRIC_PORT";
-
-    const CORRECT_WEB_HOOK: &str = "https://discord.com/api/webhooks/";
-    const CORRECT_CHECK_INTERVAL: &str = "42";
-    const CORRECT_METRIC_IP: &str = "127.0.0.1";
-    const CORRECT_METRIC_PORT: &str = "9184";
-
-    #[test]
-    fn test_from_env_missing_env() {
-        temp_env::with_vars_unset(vec![ENV_WEB_HOOK, ENV_CHECK_INTERVAL], || {
-            let result = Config::get_configurations();
-            assert!(result.is_err());
-        });
+impl FeedConfig {
+    /// The poll interval as a [`Duration`].
+    #[must_use]
+    pub fn check_interval(&self) -> Duration {
+        Duration::from_secs(self.check_interval_secs)
     }
+}
 
-    #[test]
-    fn test_from_env_minimal() {
-        temp_env::with_vars(
-            vec![
-                (ENV_WEB_HOOK, Some(CORRECT_WEB_HOOK)),
-                (ENV_CHECK_INTERVAL, Some(CORRECT_CHECK_INTERVAL)),
-            ],
-            || {
-                let result = Config::get_configurations();
-                assert!(result.is_ok());
+/// Where the Prometheus exporter listens.
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct MetricsConfig {
+    pub ip: IpAddr,
+    pub port: u16,
+}
 
-                let config = result.unwrap();
-                assert_eq!(config.discord_webhook_url.expose_secret(), CORRECT_WEB_HOOK);
-                assert_eq!(
-                    config.check_interval,
-                    Duration::from_secs(CORRECT_CHECK_INTERVAL.parse().unwrap())
-                );
-            },
-        );
+impl Default for MetricsConfig {
+    fn default() -> Self {
+        Self {
+            ip: DEFAULT_METRIC_IP,
+            port: DEFAULT_METRIC_PORT,
+        }
     }
+}
 
-    #[test]
-    fn test_from_env_full() {
-        temp_env::with_vars(
-            vec![
-                (ENV_WEB_HOOK, Some(CORRECT_WEB_HOOK)),
-                (ENV_CHECK_INTERVAL, Some(CORRECT_CHECK_INTERVAL)),
-                (ENV_METRIC_IP, Some(CORRECT_METRIC_IP)),
-                (ENV_METRIC_PORT, Some(CORRECT_METRIC_PORT)),
-            ],
-            || {
-                let result = Config::get_configurations();
-                assert!(result.is_ok());
-
-                let config = result.unwrap();
-                assert_eq!(config.discord_webhook_url.expose_secret(), CORRECT_WEB_HOOK);
-                assert_eq!(
-                    config.check_interval,
-                    Duration::from_secs(CORRECT_CHECK_INTERVAL.parse().unwrap())
-                );
-                assert_eq!(
-                    config.metric_socket,
-                    SocketAddr::new(
-                        CORRECT_METRIC_IP.parse().unwrap(),
-                        CORRECT_METRIC_PORT.parse().unwrap(),
-                    )
-                );
-            },
-        );
+impl MetricsConfig {
+    /// The address the exporter binds.
+    #[must_use]
+    pub fn socket(&self) -> SocketAddr {
+        SocketAddr::new(self.ip, self.port)
     }
+}
 
-    #[test]
-    fn test_from_env_invalid_check_interval() {
-        temp_env::with_vars(
-            vec![
-                (ENV_WEB_HOOK, Some(CORRECT_WEB_HOOK)),
-                (ENV_CHECK_INTERVAL, Some("d")),
-            ],
-            || {
-                let result = Config::get_configurations();
-                assert!(result.is_err());
-            },
-        );
-    }
+/// Logging and error reporting.
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct TelemetryConfig {
+    /// The maximum verbosity that reaches stdout, parsed at boot so an unusable value fails
+    /// the load rather than the first log line.
+    #[serde(deserialize_with = "deserialize_level")]
+    pub log_level: Level,
+    /// Sentry DSN. Absent disables Sentry entirely. Secret: a DSN is a write credential for
+    /// the project's event stream.
+    pub sentry_dsn: Option<SecretString>,
+}
 
-    #[test]
-    fn test_from_env_invalid_metric_ip() {
-        temp_env::with_vars(
-            vec![
-                (ENV_WEB_HOOK, Some(CORRECT_WEB_HOOK)),
-                (ENV_CHECK_INTERVAL, Some(CORRECT_CHECK_INTERVAL)),
-                (ENV_METRIC_IP, Some("abcde")),
-                (ENV_METRIC_PORT, Some(CORRECT_METRIC_PORT)),
-            ],
-            || {
-                let result = Config::get_configurations();
-                assert!(result.is_err());
-            },
-        );
+impl Default for TelemetryConfig {
+    fn default() -> Self {
+        Self {
+            log_level: DEFAULT_LOG_LEVEL,
+            sentry_dsn: None,
+        }
     }
+}
 
-    #[test]
-    fn test_from_env_invalid_metric_port() {
-        temp_env::with_vars(
-            vec![
-                (ENV_WEB_HOOK, Some(CORRECT_WEB_HOOK)),
-                (ENV_CHECK_INTERVAL, Some(CORRECT_CHECK_INTERVAL)),
-                (ENV_METRIC_IP, Some(CORRECT_METRIC_IP)),
-                (ENV_METRIC_PORT, Some("abcde")),
-            ],
-            || {
-                let result = Config::get_configurations();
-                assert!(result.is_err());
-            },
-        );
-    }
-
-    #[test]
-    fn test_from_env_invalid_unicode_character() {
-        temp_env::with_vars(
-            vec![(ENV_WEB_HOOK, Some("⛷")), (ENV_CHECK_INTERVAL, Some("⛷"))],
-            || {
-                let result = Config::get_configurations();
-                assert!(result.is_err());
-            },
-        );
-    }
+/// Parse a [`Level`] from any layer's string form.
+///
+/// The error names the value and the accepted set, because the previous system's failure —
+/// `LOG_LEVEL=FATAL`, a level `tracing` does not have — read only as "invalid level".
+fn deserialize_level<'de, D>(deserializer: D) -> Result<Level, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw = String::deserialize(deserializer)?;
+    Level::from_str(&raw).map_err(|_| {
+        serde::de::Error::custom(format!(
+            "invalid log level `{raw}`, expected one of TRACE, DEBUG, INFO, WARN, ERROR"
+        ))
+    })
 }

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -1,0 +1,45 @@
+//! The netcup-offer-bot dialect of [`terrace_config`].
+//!
+//! The layering itself — the TOML layer, the prefixed environment layer, the secrets-directory
+//! provider, the `_FILE` indirection and the shadow-key rejection — belongs to
+//! `terrace-config`. What stays here is the one thing that is ours: which environment names
+//! this deployment spells.
+
+use serde::de::DeserializeOwned;
+use terrace_config::Terrace;
+
+pub use terrace_config::Error as ConfigError;
+
+/// The prefix every configuration variable carries.
+const PREFIX: &str = "NETCUP_OFFER_BOT_";
+
+/// The loader the process boots through.
+///
+/// Layers, lowest precedence first: struct defaults, TOML at `$NETCUP_OFFER_BOT_CONFIG` (a
+/// file, or every `*.toml` in it if it names a directory), `NETCUP_OFFER_BOT_`-prefixed
+/// `__`-nested environment variables, `$NETCUP_OFFER_BOT_SECRETS_DIR`, and
+/// `NETCUP_OFFER_BOT_<KEY>_FILE` indirection. The last three are mutually exclusive per key: a
+/// key supplied by two of them is refused at boot rather than resolved by precedence, so a
+/// stale `NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL` cannot shadow a webhook that has since been
+/// rotated in a mounted `Secret`.
+///
+/// Both variable names below are literals even though `Terrace::new(PREFIX)` derives exactly
+/// these: the README documents them, and a name that exists only as a derivation inside a
+/// dependency is one no line of documentation can be held to. Nothing is reserved — this
+/// process reads no configuration key straight from the environment, so every key is one a
+/// file may supply.
+fn terrace() -> Terrace {
+    Terrace::new(PREFIX)
+        .config_var("NETCUP_OFFER_BOT_CONFIG")
+        .secrets_dir_var("NETCUP_OFFER_BOT_SECRETS_DIR")
+}
+
+/// Load a typed configuration.
+///
+/// # Errors
+/// Returns [`ConfigError`] if a required value is missing, a value fails to parse, a
+/// file-backed source cannot be read, or one key is supplied by more than one of the last
+/// three layers.
+pub fn load<T: DeserializeOwned>() -> Result<T, ConfigError> {
+    terrace().load()
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,10 +2,8 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("Tracing error")]
-    Logger(#[from] tracing::metadata::ParseLevelError),
     #[error("Config error: {0}")]
-    ConfigVar(#[from] std::env::VarError),
+    Config(#[from] crate::config::ConfigError),
     #[error("Parser error")]
     Parse(#[from] std::num::ParseIntError),
     #[error("Rss error: {0}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ impl FeedChecker {
             .with(TracingMiddleware::<SpanBackendWithUrl>::new())
             .build();
         let states = FeedStates::load().unwrap();
-        let hook = DiscordWebhook::new(config.discord_webhook_url.clone());
+        let hook = DiscordWebhook::new(config.discord.webhook_url.clone());
 
         FeedChecker::new(client, states, hook)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,10 +4,9 @@ extern crate tracing;
 use netcup_offer_bot::FeedChecker;
 use netcup_offer_bot::Result;
 use netcup_offer_bot::config::Config;
+use secrecy::{ExposeSecret, SecretString};
 use sentry::ClientInitGuard;
-use std::env;
 use std::net::SocketAddr;
-use std::str::FromStr;
 use tokio::time;
 use tokio_stream::StreamExt;
 use tokio_stream::wrappers::IntervalStream;
@@ -15,26 +14,23 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{Layer, filter};
 
-const ENV_SENTRY_DSN: &str = "SENTRY_DSN";
-const ENV_LOG_LEVEL: &str = "LOG_LEVEL";
-
-const DEFAULT_LOG_LEVEL: &str = "info";
-
 #[tokio::main]
 async fn main() -> Result<()> {
-    setup_tracing()?;
+    // Loaded before anything is installed: every knob below, the log level included, is part of
+    // the same layered configuration, so a failure here is reported by `main`'s `Termination`
+    // rather than by a subscriber that does not exist yet.
+    let config = Config::load()?;
 
-    let dns = env::var(ENV_SENTRY_DSN).ok();
+    setup_tracing(config.telemetry.log_level);
+
     // Prevents the process from exiting until all events are sent
-    let _sentry = setup_sentry(dns);
+    let _sentry = setup_sentry(config.telemetry.sentry_dsn.as_ref());
 
-    let config = Config::get_configurations()?;
-
-    setup_metrics(&config.metric_socket)?;
+    setup_metrics(&config.metrics.socket())?;
 
     info!("Starting feed bot");
     let mut checker = FeedChecker::from_config(&config);
-    let mut stream = IntervalStream::new(time::interval(config.check_interval));
+    let mut stream = IntervalStream::new(time::interval(config.feed.check_interval()));
     while let Some(_ts) = stream.next().await {
         checker.check_feeds().await;
     }
@@ -42,24 +38,19 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-fn setup_tracing() -> Result<()> {
-    let level = env::var(ENV_LOG_LEVEL).unwrap_or_else(|_| DEFAULT_LOG_LEVEL.to_string());
-    let level = tracing::Level::from_str(&level)?;
-
+fn setup_tracing(level: tracing::Level) {
     tracing_subscriber::registry()
         .with(tracing_subscriber::fmt::layer().with_filter(filter::LevelFilter::from_level(level)))
         .with(sentry::integrations::tracing::layer().with_filter(filter::LevelFilter::DEBUG))
         .init();
-
-    Ok(())
 }
 
-fn setup_sentry(dns: Option<String>) -> Option<ClientInitGuard> {
-    // Only enable sentry if the dns is set
-    let dns = match dns {
-        Some(dns) => dns,
+fn setup_sentry(dsn: Option<&SecretString>) -> Option<ClientInitGuard> {
+    // Only enable sentry if the dsn is set
+    let dsn = match dsn {
+        Some(dsn) => dsn,
         None => {
-            info!("{ENV_SENTRY_DSN} not set, skipping Sentry setup");
+            info!("telemetry.sentry_dsn not set, skipping Sentry setup");
             return None;
         }
     };
@@ -72,7 +63,7 @@ fn setup_sentry(dns: Option<String>) -> Option<ClientInitGuard> {
         options = options.release(release);
     }
 
-    Some(sentry::init((dns, options)))
+    Some(sentry::init((dsn.expose_secret(), options)))
 }
 
 fn setup_metrics(socket: &SocketAddr) -> Result<()> {

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,0 +1,243 @@
+//! The layered configuration, exercised through the names an operator actually sets.
+//!
+//! `terrace-config` owns the layering and tests it; what these pin is that this crate wires it
+//! to the right variables, and that the blocks deserialise with the defaults documented in
+//! `README.md` — which is why the expected values below are literals rather than references to
+//! the constants that produce them.
+//!
+//! These live in a test binary of their own rather than beside the code, because
+//! [`figment::Jail`] manipulates the *process* environment: `clear_env` unsets `TMP` along with
+//! everything else, and a `tempfile` call on another test thread then has nowhere to write. A
+//! separate binary is a separate process, so the isolation is real rather than a convention
+//! future tests have to remember.
+
+// Every test body is a closure passed to `Jail::expect_with`, which fixes the error type to the
+// large `figment::Error`. Nothing here can box it, and no `Err` is ever constructed on a hot
+// path.
+#![expect(
+    clippy::result_large_err,
+    reason = "figment::Jail::expect_with fixes the closure's error type"
+)]
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use netcup_offer_bot::config::Config;
+use secrecy::ExposeSecret;
+use tracing::Level;
+
+const WEB_HOOK: &str = "https://discord.com/api/webhooks/";
+const ENV_WEB_HOOK: &str = "NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL";
+const ENV_CHECK_INTERVAL: &str = "NETCUP_OFFER_BOT_FEED__CHECK_INTERVAL_SECS";
+const ENV_SECRETS_DIR: &str = "NETCUP_OFFER_BOT_SECRETS_DIR";
+
+/// The required keys and nothing else: what an operator has to set, plus every default that
+/// fills in around it.
+#[test]
+fn env_supplies_required_keys_and_defaults_fill_the_rest() {
+    figment::Jail::expect_with(|jail| {
+        jail.clear_env();
+        jail.set_env(ENV_WEB_HOOK, WEB_HOOK);
+        jail.set_env(ENV_CHECK_INTERVAL, "42");
+
+        let config = Config::load().map_err(|e| e.to_string()).unwrap();
+        assert_eq!(config.discord.webhook_url.expose_secret(), WEB_HOOK);
+        assert_eq!(config.feed.check_interval(), Duration::from_secs(42));
+        assert_eq!(
+            config.metrics.socket(),
+            "127.0.0.1:9184".parse::<SocketAddr>().unwrap()
+        );
+        assert_eq!(config.telemetry.log_level, Level::INFO);
+        assert!(config.telemetry.sentry_dsn.is_none());
+        Ok(())
+    });
+}
+
+/// Every optional block, set through the environment.
+#[test]
+fn env_overrides_every_default() {
+    figment::Jail::expect_with(|jail| {
+        jail.clear_env();
+        jail.set_env(ENV_WEB_HOOK, WEB_HOOK);
+        jail.set_env(ENV_CHECK_INTERVAL, "42");
+        jail.set_env("NETCUP_OFFER_BOT_METRICS__IP", "0.0.0.0");
+        jail.set_env("NETCUP_OFFER_BOT_METRICS__PORT", "9999");
+        jail.set_env("NETCUP_OFFER_BOT_TELEMETRY__LOG_LEVEL", "debug");
+        jail.set_env("NETCUP_OFFER_BOT_TELEMETRY__SENTRY_DSN", "https://sentry/1");
+
+        let config = Config::load().map_err(|e| e.to_string()).unwrap();
+        assert_eq!(
+            config.metrics.socket(),
+            "0.0.0.0:9999".parse::<SocketAddr>().unwrap()
+        );
+        assert_eq!(config.telemetry.log_level, Level::DEBUG);
+        assert_eq!(
+            config.telemetry.sentry_dsn.unwrap().expose_secret(),
+            "https://sentry/1"
+        );
+        Ok(())
+    });
+}
+
+/// The TOML layer alone is enough to boot, and `./config.toml` is found with nothing pointing
+/// at it.
+#[test]
+fn a_toml_file_supplies_the_whole_configuration() {
+    figment::Jail::expect_with(|jail| {
+        jail.clear_env();
+        jail.create_file(
+            "config.toml",
+            "[discord]\n\
+             webhook_url = \"https://discord.com/api/webhooks/toml\"\n\
+             [feed]\n\
+             check_interval_secs = 180\n\
+             [metrics]\n\
+             port = 1234\n",
+        )?;
+
+        let config = Config::load().map_err(|e| e.to_string()).unwrap();
+        assert_eq!(
+            config.discord.webhook_url.expose_secret(),
+            "https://discord.com/api/webhooks/toml"
+        );
+        assert_eq!(config.feed.check_interval(), Duration::from_secs(180));
+        assert_eq!(config.metrics.port, 1234);
+        // An untouched sibling of an overridden key still defaults.
+        assert_eq!(
+            config.metrics.ip,
+            "127.0.0.1".parse::<std::net::IpAddr>().unwrap()
+        );
+        Ok(())
+    });
+}
+
+/// The shape a Kubernetes `Secret` mounted as a volume has: one file per key. A placeholder in
+/// a `ConfigMap`'s TOML cannot win over the real webhook.
+#[test]
+fn a_secrets_directory_outranks_the_toml_layer() {
+    figment::Jail::expect_with(|jail| {
+        jail.clear_env();
+        jail.create_file(
+            "config.toml",
+            "[discord]\n\
+             webhook_url = \"https://discord.com/api/webhooks/placeholder\"\n\
+             [feed]\n\
+             check_interval_secs = 180\n",
+        )?;
+        jail.create_dir("secrets")?;
+        jail.create_file("secrets/discord__webhook_url", WEB_HOOK)?;
+        jail.set_env(ENV_SECRETS_DIR, jail.directory().join("secrets").display());
+
+        let config = Config::load().map_err(|e| e.to_string()).unwrap();
+        assert_eq!(config.discord.webhook_url.expose_secret(), WEB_HOOK);
+        Ok(())
+    });
+}
+
+/// Docker's `_FILE` convention, for a deployment that mounts one secret rather than a
+/// directory of them.
+#[test]
+fn file_indirection_supplies_a_single_key() {
+    figment::Jail::expect_with(|jail| {
+        jail.clear_env();
+        jail.set_env(ENV_CHECK_INTERVAL, "42");
+        jail.create_file("webhook", WEB_HOOK)?;
+        jail.set_env(
+            "NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL_FILE",
+            jail.directory().join("webhook").display(),
+        );
+
+        let config = Config::load().map_err(|e| e.to_string()).unwrap();
+        assert_eq!(config.discord.webhook_url.expose_secret(), WEB_HOOK);
+        Ok(())
+    });
+}
+
+/// A key supplied both by the environment and by a mounted file fails the boot instead of
+/// resolving by precedence: an environment variable left behind by a half-finished migration
+/// would otherwise keep the process posting to a webhook that has since been rotated.
+#[test]
+fn a_key_supplied_twice_is_refused() {
+    figment::Jail::expect_with(|jail| {
+        jail.clear_env();
+        jail.set_env(ENV_WEB_HOOK, WEB_HOOK);
+        jail.set_env(ENV_CHECK_INTERVAL, "42");
+        jail.create_dir("secrets")?;
+        jail.create_file("secrets/discord__webhook_url", "https://rotated/hook")?;
+        jail.set_env(ENV_SECRETS_DIR, jail.directory().join("secrets").display());
+
+        let error = Config::load().expect_err("two sources define discord.webhook_url");
+        assert!(
+            error.to_string().contains("discord.webhook_url"),
+            "the error must name the key: {error}"
+        );
+        Ok(())
+    });
+}
+
+#[test]
+fn a_missing_required_key_fails_the_load() {
+    figment::Jail::expect_with(|jail| {
+        jail.clear_env();
+        jail.set_env(ENV_CHECK_INTERVAL, "42");
+
+        assert!(Config::load().is_err());
+        Ok(())
+    });
+}
+
+#[test]
+fn an_unparsable_check_interval_fails_the_load() {
+    figment::Jail::expect_with(|jail| {
+        jail.clear_env();
+        jail.set_env(ENV_WEB_HOOK, WEB_HOOK);
+        jail.set_env(ENV_CHECK_INTERVAL, "soon");
+
+        assert!(Config::load().is_err());
+        Ok(())
+    });
+}
+
+#[test]
+fn an_unparsable_metric_ip_fails_the_load() {
+    figment::Jail::expect_with(|jail| {
+        jail.clear_env();
+        jail.set_env(ENV_WEB_HOOK, WEB_HOOK);
+        jail.set_env(ENV_CHECK_INTERVAL, "42");
+        jail.set_env("NETCUP_OFFER_BOT_METRICS__IP", "abcde");
+
+        assert!(Config::load().is_err());
+        Ok(())
+    });
+}
+
+#[test]
+fn an_unparsable_metric_port_fails_the_load() {
+    figment::Jail::expect_with(|jail| {
+        jail.clear_env();
+        jail.set_env(ENV_WEB_HOOK, WEB_HOOK);
+        jail.set_env(ENV_CHECK_INTERVAL, "42");
+        jail.set_env("NETCUP_OFFER_BOT_METRICS__PORT", "abcde");
+
+        assert!(Config::load().is_err());
+        Ok(())
+    });
+}
+
+/// `FATAL` and `ALL` were documented by the previous system and neither is a `tracing` level,
+/// so the error has to name the value and the accepted set rather than read as "invalid level".
+#[test]
+fn an_unknown_log_level_names_the_accepted_set() {
+    figment::Jail::expect_with(|jail| {
+        jail.clear_env();
+        jail.set_env(ENV_WEB_HOOK, WEB_HOOK);
+        jail.set_env(ENV_CHECK_INTERVAL, "42");
+        jail.set_env("NETCUP_OFFER_BOT_TELEMETRY__LOG_LEVEL", "FATAL");
+
+        let error = Config::load().expect_err("FATAL is not a tracing level");
+        let message = error.to_string();
+        assert!(message.contains("FATAL"), "must name the value: {message}");
+        assert!(message.contains("TRACE"), "must name the set: {message}");
+        Ok(())
+    });
+}


### PR DESCRIPTION
Migrates the environment-only configuration to [terrace-config](https://github.com/TimSchoenle/terrace-config), the layered loader [TankoVault](https://github.com/TimSchoenle/TankoVault) boots through.

## Why

The Discord webhook is the one credential this process holds, and it could only be supplied as an environment variable — visible in `docker inspect`, present in the environment of every child process, and impossible to rotate without recreating the container. It can now arrive as a mounted Kubernetes `Secret` or a Docker secret file.

## The layers

Lowest precedence first:

1. Struct defaults.
2. TOML at `$NETCUP_OFFER_BOT_CONFIG`, default `./config.toml` — a file, or every `*.toml` in it when it names a directory. A missing file is not an error.
3. `NETCUP_OFFER_BOT_`-prefixed, `__`-nested environment variables.
4. Every key-named file in `$NETCUP_OFFER_BOT_SECRETS_DIR`.
5. `NETCUP_OFFER_BOT_<KEY>_FILE=/path`.

Layers 3–5 are mutually exclusive per key: a key supplied by two of them fails the boot naming the key and both sources, rather than resolving by precedence. That is the point of the crate — a stale environment variable shadowing a webhook that has since been rotated would otherwise keep the bot posting to the old one, and the discrepancy would surface long after the deploy that caused it.

## What changed beyond the loader

- The flat `RawConfig` becomes four blocks: `discord`, `feed`, `metrics`, `telemetry`. `SENTRY_DSN` and `LOG_LEVEL` were read straight out of the environment by `main`; they are part of the layered configuration now, so a file can supply them too.
- The metrics address and the log level are parsed at load rather than at use, so an unusable value fails the boot instead of the first log line. The log-level error names the accepted set — `FATAL` and `ALL` were documented in the README but are not `tracing` levels.
- The Sentry DSN is wrapped in `SecretString` alongside the webhook.
- Dependencies: `config` and `temp-env` out, `terrace-config` (pinned by tag `v0.2.0`) and `figment` (dev, for `Jail`) in. Net **−22** crates in `Cargo.lock`.
- `config.toml` added to `.gitignore` and `.dockerignore`: it is the default TOML layer, so a working copy of it holds the real webhook.

## Tests

The config tests move to `tests/config.rs`. `figment::Jail` manipulates the *process* environment, and `clear_env` unsetting `TMP` left `tempfile` calls on other test threads writing to `C:\WINDOWS`; a separate test binary is a separate process, so the isolation is real rather than a convention future tests have to remember. Eleven tests cover each layer, the precedence between them, the shadow rejection, and every parse failure.

`cargo test`, `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` are clean locally.

## Breaking

Every variable is renamed and nested:

| Before | After |
|---|---|
| `WEB_HOOK` | `NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL` |
| `CHECK_INTERVAL` | `NETCUP_OFFER_BOT_FEED__CHECK_INTERVAL_SECS` |
| `METRIC_IP` | `NETCUP_OFFER_BOT_METRICS__IP` |
| `METRIC_PORT` | `NETCUP_OFFER_BOT_METRICS__PORT` |
| `LOG_LEVEL` | `NETCUP_OFFER_BOT_TELEMETRY__LOG_LEVEL` |
| `SENTRY_DSN` | `NETCUP_OFFER_BOT_TELEMETRY__SENTRY_DSN` |

An old name is ignored rather than rejected, so a deployment that is not updated fails at boot on the missing webhook rather than running mute. **The [Helm chart](https://github.com/TimSchoenle/helm-charts/tree/main/charts/netcup-offer-bot) lives in another repository and needs the same rename.**

Note also that `METRIC_IP` documented a default of `0.0.0.0` while the code defaulted to `127.0.0.1`. The code's default is kept and the README corrected; a deployment that relied on the documented value has to set `NETCUP_OFFER_BOT_METRICS__IP` explicitly.

`feat!` bumps this to 2.0.0 in the release-please PR. Say if you would rather it went out as a minor.

## Left out

`terrace-config`'s `reload` supervisor. It rebuilds everything the closure constructs, and the Prometheus exporter binds its socket process-globally at startup — a rebuild would fail to re-bind. Wiring it needs the exporter moved into the rebuilt runtime, which is its own change.
