### PR TITLE
feat(config): update terrace-config to 0.5.0 and generate the README

### DIFF
--- a/.github/templates/README.md.hbs
+++ b/.github/templates/README.md.hbs
@@ -1,0 +1,154 @@
+<!--
+Generated from .github/templates/README.md.hbs — edit that file, not this one. CI renders it on
+every pull request and commits the result back to the branch; a push to master whose README.md
+does not match its template fails the `readme` check in .github/workflows/docs.yaml.
+
+Variables come from `cargo run --features config-schema --example readme-variables`:
+
+    version              the [package] version, e.g. 2.0.1
+    repository           the GitHub repository, as owner/name
+    branch               the branch permanent links point at
+    image                the Docker Hub repository the image is published to
+    prefix               the prefix every configuration variable carries
+    nesting_separator    what separates nesting levels in an environment key
+    indirection_suffix   what marks a variable holding a path rather than a value
+    config_loader        the table of variables the loader reads
+    config_keys          the table of configuration keys
+    config_toml          a config.toml carrying every key
+
+The last three are derived from the `Config` type itself, by way of terrace-config's `schema`
+feature. Adding a key, changing a default or rewriting a field's doc comment updates this page in
+the same commit that changes the code — which is the point: a reference table maintained beside
+the type is a table that is wrong by the second release.
+-->
+<br/>
+<p align="center">
+  <h3 align="center">Netcup Offer Bot</h3>
+
+  <p align="center">
+    <a href="https://github.com/{{ repository }}/issues">Report Bug</a>
+    .
+    <a href="https://github.com/{{ repository }}/issues">Request Feature</a>
+  </p>
+</p>
+
+<div align="center">
+
+![Docker Image Version (latest semver)](https://img.shields.io/docker/v/{{ image }})
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/{{ repository }}/build.yaml)
+![Issues](https://img.shields.io/github/issues/{{ repository }})
+[![codecov](https://codecov.io/gh/{{ repository }}/branch/{{ branch }}/graph/badge.svg?token=JEK95V1906)](https://codecov.io/gh/{{ repository }})
+![License](https://img.shields.io/github/license/{{ repository }})
+
+</div>
+
+## About The Project
+
+RSS feed listener to discord webhook for https://www.netcup.com/de/deals
+
+### Installation - Helm chart
+
+- [Helm chart](https://github.com/TimSchoenle/helm-charts/tree/main/charts/netcup-offer-bot)
+
+### Installation - Docker
+
+- [Docker Image](https://hub.docker.com/repository/docker/{{ image }})
+
+The image is published as a multi-platform manifest for `linux/amd64` and `linux/arm64`. Docker pulls
+the matching architecture automatically, so the commands below are identical on both.
+
+#### Quick start
+
+The examples pin `{{ version }}`, the release this page was generated from; `latest` tracks the newest.
+
+```shell
+  docker run \
+    --name netcup-offer-bot \
+    -e {{ prefix }}DISCORD{{ nesting_separator }}WEBHOOK_URL="https://discord.com/api/webhooks/..." \
+    -e {{ prefix }}FEED{{ nesting_separator }}CHECK_INTERVAL_SECS="180" \
+    -v netcup-offer-bot-data:/app/data \
+    -d \
+    {{ image }}:{{ version }}
+  ```
+
+## Configuration
+
+Configuration is layered by [terrace-config](https://github.com/TimSchoenle/terrace-config), so the
+Discord webhook can arrive as a mounted file rather than as an environment variable that shows up
+in `docker inspect` and in the environment of every child process.
+
+Lowest precedence first:
+
+1. The defaults compiled into the config structs.
+2. TOML at `${{ prefix }}CONFIG`, defaulting to `./config.toml` — a file, or every `*.toml`
+   directly inside it when it names a directory, merged in file-name order. A missing file is not
+   an error.
+3. `{{ prefix }}`-prefixed environment variables.
+4. Every key-named file in `${{ prefix }}SECRETS_DIR`.
+5. `{{ prefix }}<KEY>{{ indirection_suffix }}=/path`, which reads `<KEY>` from that path.
+
+**Layers 3, 4 and 5 are mutually exclusive per key.** A key supplied by two of them fails the boot
+naming the key and both sources, rather than being resolved by precedence: a stale environment
+variable shadowing a webhook that has since been rotated would otherwise keep the bot posting to
+the old one, and the discrepancy would surface long after the deploy that caused it.
+
+**Nesting is `{{ nesting_separator }}`** — a single underscore is part of a field name. Case is folded,
+so `discord.webhook_url` is `{{ prefix }}DISCORD{{ nesting_separator }}WEBHOOK_URL` as a variable and
+`discord{{ nesting_separator }}webhook_url` as a file name.
+
+Run with `{{ prefix }}TELEMETRY{{ nesting_separator }}LOG_LEVEL=DEBUG` and the boot log names the layer
+every key was read from, which is what answers "the `Secret` is mounted and the bot is still posting
+to the old webhook".
+
+#### The variables read before the layers exist
+
+These decide what the layers *are*, so no layer can supply them.
+
+{{{ config_loader }}}
+
+#### Keys
+
+{{{ config_keys }}}
+
+Every key has two further spellings, both mechanical and both left out of the table to keep it inside
+a page: appending `{{ indirection_suffix }}` to the environment variable names a *file* holding the value,
+and the TOML path with `.` replaced by `{{ nesting_separator }}` is that key's file name inside the secrets
+directory.
+
+#### `config.toml`
+
+Every key, commented out wherever leaving it out changes nothing, so this file and an empty one mean
+the same thing to the loader. What is left uncommented is exactly what has to be supplied — and each
+of those carries a placeholder rather than a value, so a copy left unedited fails at the key that was
+never filled in rather than running on it.
+
+```toml
+{{{ config_toml }}}
+```
+
+#### Secrets from files
+
+A Kubernetes `Secret` mounted as a volume, one file per key — the provider follows the `..data`
+indirection a projected volume uses, so the mount works as written:
+
+```shell
+  docker run \
+    --name netcup-offer-bot \
+    -e {{ prefix }}SECRETS_DIR="/run/secrets" \
+    -e {{ prefix }}FEED{{ nesting_separator }}CHECK_INTERVAL_SECS="180" \
+    -v ./webhook:/run/secrets/discord{{ nesting_separator }}webhook_url:ro \
+    -v netcup-offer-bot-data:/app/data \
+    -d \
+    {{ image }}:{{ version }}
+  ```
+
+Or Docker's `{{ indirection_suffix }}` convention, for a single secret:
+
+```shell
+  -e {{ prefix }}DISCORD{{ nesting_separator }}WEBHOOK_URL{{ indirection_suffix }}="/run/secrets/webhook"
+  ```
+
+## License
+
+Distributed under the MIT License. See [LICENSE](https://github.com/{{ repository }}/blob/{{ branch }}/LICENSE)
+for more information.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,6 +72,12 @@ jobs:
       name: ci
       deployment: false
     runs-on: ubuntu-latest
+    # Shared with docs.yaml rather than with the rest of this workflow: both jobs commit to the
+    # pull request branch through the API, which rejects a commit whose parent has moved. Racing
+    # them would fail one of the two for a reason its log does not explain, so they queue.
+    concurrency:
+      group: branch-writes-${{ github.ref }}
+      cancel-in-progress: false
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,141 @@
+name: Docs
+
+# `README.md` is generated from `.github/templates/README.md.hbs`. This workflow is what makes
+# that claim true in both directions.
+#
+# On a pull request it renders the template and commits the result to the branch, so nothing the
+# README quotes is ever edited by hand: not the crate version its `docker run` examples pin, and
+# not the configuration tables, which are derived from the `Config` type by the
+# `readme-variables` example. The case that matters most is the release-please pull request —
+# that commit is the one which changes `version` in `Cargo.toml`, so it is also the one where the
+# README would otherwise start advertising the previous release. Rendering here means the
+# released README already pins the version the merge is about to publish.
+#
+# Everywhere it cannot commit — a push to `master`, a pull request from a fork — it renders in
+# `check` mode instead, writing nothing and failing if the committed `README.md` is stale.
+# Without it, editing `README.md` directly would appear to work right up until the next pull
+# request silently reverted it.
+
+on:
+  push:
+    branches: [ "master" ]
+
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+# Shared with the `fmt` job in build.yaml rather than scoped to this workflow: both commit to the
+# pull request branch, and the API call that makes a verified commit rejects one whose parent has
+# moved. Two writers racing would leave one of them failing for no reason a reader could act on,
+# so they queue instead. `cancel-in-progress: false` for the same reason — a cancelled run here
+# means a branch left holding a half-generated file.
+concurrency:
+  group: branch-writes-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  render:
+    name: Render
+    # Forks get no secrets, so the App token would be empty and the commit could not be pushed to
+    # their branch anyway. `check` below picks those pull requests up instead.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    environment:
+      name: ci
+      deployment: false
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read # the write happens with the App token below, not with GITHUB_TOKEN
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      # An App installation token, so the commit is verified and — unlike one made with
+      # `GITHUB_TOKEN` — re-triggers the checks on the branch it lands on.
+      - name: Generate Bot Token
+        id: generate_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.ACTIONS_MAINTENANCE_APP_ID }}
+          private-key: ${{ secrets.ACTIONS_MAINTENANCE_PRIVATE_KEY }}
+          permission-contents: write
+
+      # The head of the branch, not the merge commit: the render has to read the `Cargo.toml` and
+      # the `Config` the pull request proposes, and the commit has to land on top of what is
+      # there now.
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.head_ref }}
+          persist-credentials: false
+
+      - name: Install stable toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+
+      - name: Collect README variables
+        id: variables
+        run: echo "json=$(cargo run --quiet --features config-schema --example readme-variables)" >> "$GITHUB_OUTPUT"
+
+      - name: Render and commit the README
+        id: readme
+        uses: TimSchoenle/actions/actions/common/render-template-and-commit@15d83f02081c9dc8a844646199c63792dcccdfa8 # tag=actions-common-render-template-and-commit-v1.1.3
+        with:
+          template: .github/templates/README.md.hbs
+          output: README.md
+          variables: ${{ steps.variables.outputs.json }}
+          token: ${{ steps.generate_token.outputs.token }}
+          commit_message: "docs: render README from template"
+
+      - name: Summarise
+        env:
+          COMMITTED: ${{ steps.readme.outputs.changes_detected }}
+          COMMIT_URL: ${{ steps.readme.outputs.commit_url }}
+        run: |
+          if [ "${COMMITTED}" = "true" ]; then
+            echo "README.md re-rendered: ${COMMIT_URL}" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "README.md already matched its template." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  check:
+    name: README
+    # The complement of `render`: it covers the pushes to `master` that no pull request rendered,
+    # and the fork pull requests that could not be committed to. Between the two conditions every
+    # event this workflow sees is handled by exactly one job.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read # Required to checkout the code
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Install stable toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+
+      - name: Collect README variables
+        id: variables
+        run: echo "json=$(cargo run --quiet --features config-schema --example readme-variables)" >> "$GITHUB_OUTPUT"
+
+      # Writes nothing; fails with the first differing line when README.md is stale.
+      - name: Verify README.md is current
+        uses: TimSchoenle/actions/actions/common/render-template@3b7d152374ee63e720e7c16bed8b088b40554911 # tag=actions-common-render-template-v1.1.1
+        with:
+          template: .github/templates/README.md.hbs
+          output: README.md
+          variables: ${{ steps.variables.outputs.json }}
+          check: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1138,7 +1138,6 @@ dependencies = [
  "anyhow",
  "backtrace",
  "chrono",
- "figment",
  "prometheus 0.14.0",
  "prometheus_exporter",
  "reqwest",
@@ -2184,12 +2183,25 @@ dependencies = [
 
 [[package]]
 name = "terrace-config"
-version = "0.2.0"
-source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.2.0#46d924c25af6a0e67f657686f996539482e8abe3"
+version = "0.5.0"
+source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.5.0#b47ca70cefaf48484682a0913dbef48ba4eba10c"
 dependencies = [
  "figment",
  "serde",
+ "serde_json",
+ "terrace-config-macros",
  "thiserror 2.0.20",
+ "tokio",
+]
+
+[[package]]
+name = "terrace-config-macros"
+version = "0.5.0"
+source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.5.0#b47ca70cefaf48484682a0913dbef48ba4eba10c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,19 @@ path = "src/lib.rs"
 path = "src/main.rs"
 name = "netcup-offer-bot"
 
+# The documentation job, and nothing else. `terrace-config/schema` links `serde_json` and
+# compiles a derive macro over every config struct, which is weight an image that will never
+# print a table has no reason to carry — so the container builds with default features and CI
+# turns this on for the one step that renders the README.
+[features]
+config-schema = ["terrace-config/schema"]
+
+# Declared so `cargo clippy --all-targets --features config-schema` keeps the generator
+# compiling; `required-features` is what keeps it out of every build that does not ask for it.
+[[example]]
+name = "readme-variables"
+required-features = ["config-schema"]
+
 [dependencies]
 anyhow = { version = "1.0.100", features = ["backtrace"] }
 thiserror = "2.0.18"
@@ -24,22 +37,37 @@ tokio = { version = "1.49.0", features = ["full"] }
 tokio-stream = "0.1.18"
 tracing = "0.1.44"
 tracing-subscriber = "0.3.22"
-serde = "1.0.228"
+# `derive` spelled out rather than inherited: the config structs derive `Deserialize`, and
+# relying on another dependency to have enabled the feature makes this crate stop compiling
+# the day that dependency drops it.
+serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 prometheus = { version = "0.14.0", features = ["process"] }
 prometheus_exporter = "0.8.5"
 secrecy = { version = "0.10.3", features = ["serde"] }
 # The layered loader: struct defaults, TOML, prefixed environment, a secrets directory and
 # `_FILE` indirection, so a mounted Kubernetes `Secret` can supply the webhook URL instead of an
-# environment variable. `loader` only — the `reload` supervisor would link notify and is not
-# usable here while the Prometheus exporter binds its socket process-globally.
+# environment variable.
+#
+# `explain` rides along because it costs no dependency at all — it is a second walk of the
+# layers and the strings that render it — and it answers the one question this deployment
+# actually gets asked: why a webhook mounted from a `Secret` is not the one being used. The boot
+# log prints it at `DEBUG`, so an operator turning the level up gets the answer without a
+# debugger.
+#
+# `reload` is deliberately absent: the supervisor would link notify, and rebuilding the runtime
+# is not usable here while the Prometheus exporter binds its socket process-globally. `schema`
+# is absent for the same kind of reason and arrives through the `config-schema` feature above,
+# which the container never enables.
+#
 # Pinned by tag, not branch: `cargo update` cannot then move the dependency silently.
-terrace-config = { git = "https://github.com/TimSchoenle/terrace-config", tag = "v0.2.0", default-features = false, features = ["loader"] }
+terrace-config = { git = "https://github.com/TimSchoenle/terrace-config", tag = "v0.5.0", default-features = false, features = ["loader", "explain"] }
 
 [dev-dependencies]
-# `figment::Jail` gives the config tests a scratch directory and an environment it restores
-# afterwards. The same figment `terrace-config` resolves, plus its `test` feature.
-figment = { version = "=0.10.19", features = ["test"] }
+# The same dependency as above with its test harness added, not a second copy: cargo unions the
+# features for test builds. `testing` derives every name it writes from the loader the harness
+# was built over, so a test cannot go on asserting a variable this crate has stopped reading.
+terrace-config = { git = "https://github.com/TimSchoenle/terrace-config", tag = "v0.5.0", default-features = false, features = ["testing"] }
 tempfile = "=3.27.0"
 serde_test = "=1.0.177"
 wiremock = "=0.6.5"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
+<!--
+Generated from .github/templates/README.md.hbs — edit that file, not this one. CI renders it on
+every pull request and commits the result back to the branch; a push to master whose README.md
+does not match its template fails the `readme` check in .github/workflows/docs.yaml.
+
+Variables come from `cargo run --features config-schema --example readme-variables`:
+
+    version              the [package] version, e.g. 2.0.1
+    repository           the GitHub repository, as owner/name
+    branch               the branch permanent links point at
+    image                the Docker Hub repository the image is published to
+    prefix               the prefix every configuration variable carries
+    nesting_separator    what separates nesting levels in an environment key
+    indirection_suffix   what marks a variable holding a path rather than a value
+    config_loader        the table of variables the loader reads
+    config_keys          the table of configuration keys
+    config_toml          a config.toml carrying every key
+
+The last three are derived from the `Config` type itself, by way of terrace-config's `schema`
+feature. Adding a key, changing a default or rewriting a field's doc comment updates this page in
+the same commit that changes the code — which is the point: a reference table maintained beside
+the type is a table that is wrong by the second release.
+-->
 <br/>
 <p align="center">
   <h3 align="center">Netcup Offer Bot</h3>
@@ -12,7 +35,7 @@
 <div align="center">
 
 ![Docker Image Version (latest semver)](https://img.shields.io/docker/v/timmi6790/netcup-offer-bot)
-![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/TimSchoenle/netcup-offer-bot/build.yml)
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/TimSchoenle/netcup-offer-bot/build.yaml)
 ![Issues](https://img.shields.io/github/issues/TimSchoenle/netcup-offer-bot)
 [![codecov](https://codecov.io/gh/TimSchoenle/netcup-offer-bot/branch/master/graph/badge.svg?token=JEK95V1906)](https://codecov.io/gh/TimSchoenle/netcup-offer-bot)
 ![License](https://img.shields.io/github/license/TimSchoenle/netcup-offer-bot)
@@ -36,6 +59,8 @@ the matching architecture automatically, so the commands below are identical on 
 
 #### Quick start
 
+The examples pin `2.0.1`, the release this page was generated from; `latest` tracks the newest.
+
 ```shell
   docker run \
     --name netcup-offer-bot \
@@ -43,7 +68,7 @@ the matching architecture automatically, so the commands below are identical on 
     -e NETCUP_OFFER_BOT_FEED__CHECK_INTERVAL_SECS="180" \
     -v netcup-offer-bot-data:/app/data \
     -d \
-    timmi6790/netcup-offer-bot:latest
+    timmi6790/netcup-offer-bot:2.0.1
   ```
 
 ## Configuration
@@ -67,44 +92,78 @@ naming the key and both sources, rather than being resolved by precedence: a sta
 variable shadowing a webhook that has since been rotated would otherwise keep the bot posting to
 the old one, and the discrepancy would surface long after the deploy that caused it.
 
-**Nesting is `__` (two underscores)** — a single underscore is part of a field name. Case is
-folded, so `discord.webhook_url` is `NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL` as a variable and
+**Nesting is `__`** — a single underscore is part of a field name. Case is folded,
+so `discord.webhook_url` is `NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL` as a variable and
 `discord__webhook_url` as a file name.
+
+Run with `NETCUP_OFFER_BOT_TELEMETRY__LOG_LEVEL=DEBUG` and the boot log names the layer
+every key was read from, which is what answers "the `Secret` is mounted and the bot is still posting
+to the old webhook".
+
+#### The variables read before the layers exist
+
+These decide what the layers *are*, so no layer can supply them.
+
+| Variable | Role | Default | Purpose |
+|---|---|---|---|
+| `NETCUP_OFFER_BOT_CONFIG` | config | `config.toml` | Names the TOML layer: a file, or a directory whose `*.toml` files are all merged in name order. |
+| `NETCUP_OFFER_BOT_SECRETS_DIR` | secrets dir | — | Names a directory of key-named files — a mounted Kubernetes `Secret` volume. Each file supplies the key its name spells. |
 
 #### Keys
 
-| Key                                        | Required | Default     | Description                                              |
-|--------------------------------------------|----------|-------------|----------------------------------------------------------|
-| `NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL`    | X        |             | Discord webhook the offers are posted to                 |
-| `NETCUP_OFFER_BOT_FEED__CHECK_INTERVAL_SECS` | X      |             | Seconds between two RSS feed checks                      |
-| `NETCUP_OFFER_BOT_METRICS__IP`             |          | `127.0.0.1` | Prometheus exporter address                              |
-| `NETCUP_OFFER_BOT_METRICS__PORT`           |          | `9184`      | Prometheus exporter port                                 |
-| `NETCUP_OFFER_BOT_TELEMETRY__LOG_LEVEL`    |          | `INFO`      | One of `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`         |
-| `NETCUP_OFFER_BOT_TELEMETRY__SENTRY_DSN`   |          |             | Sentry DSN; unset disables Sentry entirely               |
+| TOML | Type | Environment | Default | Flags | Purpose |
+|---|---|---|---|---|---|
+| `discord.webhook_url` | `SecretString` | `NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL` | — | required, secret | Discord webhook the offers are posted to. |
+| `feed.check_interval_secs` | `u64` | `NETCUP_OFFER_BOT_FEED__CHECK_INTERVAL_SECS` | — | required | Seconds between two RSS feed checks. |
+| `metrics.ip` | `IpAddr` | `NETCUP_OFFER_BOT_METRICS__IP` | `127.0.0.1` | — | Address the Prometheus exporter binds. `0.0.0.0` to reach it from outside the container. |
+| `metrics.port` | `u16` | `NETCUP_OFFER_BOT_METRICS__PORT` | `9184` | — | Port the Prometheus exporter listens on. |
+| `telemetry.log_level` | `Level` | `NETCUP_OFFER_BOT_TELEMETRY__LOG_LEVEL` | `INFO` | — | The maximum verbosity that reaches stdout: `TRACE`, `DEBUG`, `INFO`, `WARN` or `ERROR`, in any case. |
+| `telemetry.sentry_dsn` | `SecretString` | `NETCUP_OFFER_BOT_TELEMETRY__SENTRY_DSN` | unset | secret | Sentry DSN. Unset disables Sentry entirely. |
 
-Two further variables are read to decide what the layers *are*, and so cannot themselves be
-supplied by a layer:
-
-| Key                             | Default       | Description                                                        |
-|---------------------------------|---------------|--------------------------------------------------------------------|
-| `NETCUP_OFFER_BOT_CONFIG`       | `config.toml` | The TOML layer: a file, or a directory whose `*.toml` are merged   |
-| `NETCUP_OFFER_BOT_SECRETS_DIR`  |               | Directory of key-named files. Unset disables the layer; set but unreadable fails the boot |
+Every key has two further spellings, both mechanical and both left out of the table to keep it inside
+a page: appending `_FILE` to the environment variable names a *file* holding the value,
+and the TOML path with `.` replaced by `__` is that key's file name inside the secrets
+directory.
 
 #### `config.toml`
 
+Every key, commented out wherever leaving it out changes nothing, so this file and an empty one mean
+the same thing to the loader. What is left uncommented is exactly what has to be supplied — and each
+of those carries a placeholder rather than a value, so a copy left unedited fails at the key that was
+never filled in rather than running on it.
+
 ```toml
 [discord]
-webhook_url = "https://discord.com/api/webhooks/..."
+# Discord webhook the offers are posted to.
+# Type: SecretString
+# Required: nothing loads until this key is supplied.
+# Secret: the value below is a placeholder.
+webhook_url = "<secret>"
 
 [feed]
-check_interval_secs = 180
+# Seconds between two RSS feed checks.
+# Type: u64
+# Required: nothing loads until this key is supplied.
+check_interval_secs = 0
 
 [metrics]
-ip = "0.0.0.0"
-port = 9184
+# Address the Prometheus exporter binds. `0.0.0.0` to reach it from outside the container.
+# Type: IpAddr
+# ip = "127.0.0.1"
+
+# Port the Prometheus exporter listens on.
+# Type: u16
+# port = 9184
 
 [telemetry]
-log_level = "INFO"
+# The maximum verbosity that reaches stdout: `TRACE`, `DEBUG`, `INFO`, `WARN` or `ERROR`, in any case.
+# Type: Level
+# log_level = "INFO"
+
+# Sentry DSN. Unset disables Sentry entirely.
+# Type: SecretString
+# Secret: the value below is a placeholder.
+# sentry_dsn = "<secret>"
 ```
 
 #### Secrets from files
@@ -120,7 +179,7 @@ indirection a projected volume uses, so the mount works as written:
     -v ./webhook:/run/secrets/discord__webhook_url:ro \
     -v netcup-offer-bot-data:/app/data \
     -d \
-    timmi6790/netcup-offer-bot:latest
+    timmi6790/netcup-offer-bot:2.0.1
   ```
 
 Or Docker's `_FILE` convention, for a single secret:
@@ -131,6 +190,5 @@ Or Docker's `_FILE` convention, for a single secret:
 
 ## License
 
-Distributed under the MIT License. See [LICENSE](https://github.com/TimSchoenle/netcup-offer-bot/blob/main/LICENSE.md)
-for
-more information.
+Distributed under the MIT License. See [LICENSE](https://github.com/TimSchoenle/netcup-offer-bot/blob/master/LICENSE)
+for more information.

--- a/examples/readme-variables.rs
+++ b/examples/readme-variables.rs
@@ -1,0 +1,121 @@
+//! Emit the variables `.github/templates/README.md.hbs` is rendered with.
+//!
+//! `README.md` is generated. This is the other half of that: the template holds the prose and
+//! this holds every value in it that is derivable from the code, so neither can drift from the
+//! crate it documents.
+//!
+//! ```text
+//! cargo run --quiet --features config-schema --example readme-variables
+//! ```
+//!
+//! One line of strict JSON on stdout, which is exactly what the `variables` input of
+//! `TimSchoenle/actions/actions/common/render-template-and-commit` takes. `serde_json` does the
+//! escaping, so a generated Markdown table full of `"`, `\` and newlines survives the trip
+//! through a workflow output verbatim — the reason this is a Rust example and not a shell
+//! script assembling JSON with `printf`.
+//!
+//! It reads nothing from the environment, so it produces the same answer on a developer's
+//! machine and on a runner where none of the variables it describes are set. Rendering is
+//! deterministic for the same reason, which is what lets `.github/workflows/docs.yaml` verify a
+//! committed `README.md` by re-rendering it.
+
+use std::error::Error;
+use std::process::ExitCode;
+
+use netcup_offer_bot::config;
+use serde::Serialize;
+use terrace_config::schema::{Column, TomlExample};
+
+/// The GitHub repository, as `owner/name`.
+///
+/// Both the shields.io badges and the issue links are built from it, so moving the repository
+/// is one edit here rather than eight in the template.
+const REPOSITORY: &str = "TimSchoenle/netcup-offer-bot";
+
+/// The branch the permanent links in the README point at.
+const BRANCH: &str = "master";
+
+/// The Docker Hub repository the image is published to.
+///
+/// Not derivable from the manifest: the namespace is a Docker Hub account rather than the
+/// GitHub owner, and the two names differ.
+const IMAGE: &str = "timmi6790/netcup-offer-bot";
+
+/// Everything `README.md.hbs` may reference.
+///
+/// Strict mode is on in the workflow, so a template naming something absent here fails the
+/// render rather than silently emitting an empty table.
+#[derive(Serialize)]
+struct Variables {
+    /// The crate version, e.g. `2.0.1`.
+    version: &'static str,
+    /// The GitHub repository, as `owner/name`.
+    repository: &'static str,
+    /// The branch permanent links point at.
+    branch: &'static str,
+    /// The Docker Hub repository, as `namespace/name`.
+    image: &'static str,
+    /// The prefix every configuration variable carries, e.g. `NETCUP_OFFER_BOT_`.
+    prefix: String,
+    /// What separates nesting levels in an environment key, e.g. `__`.
+    nesting_separator: String,
+    /// What marks a variable holding a path rather than a value, e.g. `_FILE`.
+    indirection_suffix: String,
+    /// The table of variables the loader reads before the layers exist.
+    config_loader: String,
+    /// The table of configuration keys.
+    config_keys: String,
+    /// A `config.toml` carrying every key, commented out where it has a default.
+    config_toml: String,
+}
+
+fn main() -> ExitCode {
+    match variables() {
+        Ok(json) => {
+            println!("{json}");
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("readme-variables: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+/// Build the payload.
+///
+/// # Errors
+/// Returns an error if the schema cannot be built or the payload cannot be encoded. Neither
+/// depends on the machine this runs on, so either is a bug in the annotations on `Config`.
+fn variables() -> Result<String, Box<dyn Error>> {
+    let schema = config::schema()?;
+
+    // No preamble and no per-key spellings: the README states both, immediately above this
+    // snippet and in far more detail than a comment in a file can. What is left is what the
+    // section is for — the shape of the file, with every key in it.
+    let example = TomlExample::new().header(false).spellings(false);
+
+    let variables = Variables {
+        version: env!("CARGO_PKG_VERSION"),
+        repository: REPOSITORY,
+        branch: BRANCH,
+        image: IMAGE,
+        prefix: schema.dialect.prefix.clone(),
+        nesting_separator: schema.dialect.nesting_separator.clone(),
+        indirection_suffix: schema.dialect.indirection_suffix.clone(),
+        config_loader: block(&schema.to_markdown_loader()),
+        config_keys: block(&schema.to_markdown_keys(Column::DEFAULT)),
+        config_toml: block(&schema.to_toml_example_with(&example)),
+    };
+
+    Ok(serde_json::to_string(&variables)?)
+}
+
+/// One rendered block, without its trailing newline.
+///
+/// Every rendering ends with one so that appending the next needs no separator. A template does
+/// its own spacing, so carrying the newline through would put a blank line after each block
+/// that the template did not ask for and cannot remove.
+fn block(rendered: &str) -> String {
+    rendered.trim_end().to_owned()
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,14 @@
 //! Every layer spells a field the same way: `__` separates nesting levels and case is folded,
 //! so `discord.webhook_url` is `NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL` as a variable and
 //! `discord__webhook_url` as a file name.
+//!
+//! # The doc comments below are documentation output
+//!
+//! Under the `config-schema` feature these structs also derive `Describe`, and the
+//! configuration tables in `README.md` are generated from what it reports: every key path,
+//! every environment spelling, every default, and the *first paragraph* of each field's doc
+//! comment. Write that paragraph for an operator setting the value — anything below it stays
+//! here, for whoever reads the type.
 
 mod loader;
 
@@ -25,20 +33,34 @@ use secrecy::SecretString;
 use serde::{Deserialize, Deserializer};
 use tracing::Level;
 
-pub use loader::ConfigError;
+pub use loader::{ConfigError, explain, terrace};
 
 const DEFAULT_METRIC_IP: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
 const DEFAULT_METRIC_PORT: u16 = 9184;
 const DEFAULT_LOG_LEVEL: Level = Level::INFO;
 
 /// Everything the process reads before it starts.
+///
+/// The two derives behind `config-schema` are the documentation job's: `Describe` reports the
+/// keys and `Serialize` is what the generator reads the `Default` column out of. Neither has
+/// another reason to exist here, since the loader only ever *deserialises* — and the
+/// `#[config(...)]` attributes are gated the same way, because a helper attribute without the
+/// derive that declares it is a compile error rather than a no-op.
 #[derive(Debug, Deserialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(serde::Serialize, terrace_config::schema::Describe)
+)]
 pub struct Config {
+    #[cfg_attr(feature = "config-schema", config(nested))]
     pub discord: DiscordConfig,
+    #[cfg_attr(feature = "config-schema", config(nested))]
     pub feed: FeedConfig,
     #[serde(default)]
+    #[cfg_attr(feature = "config-schema", config(nested))]
     pub metrics: MetricsConfig,
     #[serde(default)]
+    #[cfg_attr(feature = "config-schema", config(nested))]
     pub telemetry: TelemetryConfig,
 }
 
@@ -54,20 +76,76 @@ impl Config {
     }
 }
 
+/// The value the generated `Default` column is read out of, and nothing else.
+///
+/// Behind the feature because it is not a configuration this process could run on: the two
+/// required keys have no meaningful default, and the schema skips them for exactly that
+/// reason — a required key that printed a default would tell an operator they may leave it
+/// out. Every value the table does show comes from the two blocks below, through the same
+/// `Default` impls the loader itself falls back to.
+///
+/// Adding a block to [`Config`] fails to compile until it is added here too, which is what
+/// keeps the column from quietly losing a row.
+#[cfg(feature = "config-schema")]
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            discord: DiscordConfig {
+                webhook_url: SecretString::from(String::new()),
+            },
+            feed: FeedConfig {
+                check_interval_secs: 0,
+            },
+            metrics: MetricsConfig::default(),
+            telemetry: TelemetryConfig::default(),
+        }
+    }
+}
+
+/// The configuration surface as a schema, with its `Default` column filled in.
+///
+/// The generated half of `README.md`. It reads nothing from the environment, so it produces
+/// the same answer on a developer's machine and on a runner where none of the variables it
+/// describes are set.
+///
+/// # Errors
+/// Returns [`ConfigError`] if [`Config::default`] cannot be serialised, which is a bug in the
+/// annotations above rather than in anything an operator did.
+#[cfg(feature = "config-schema")]
+pub fn schema() -> Result<terrace_config::schema::Schema, ConfigError> {
+    loader::schema::<Config>().with_defaults_from(&Config::default())
+}
+
 /// Where new offers are announced.
 #[derive(Debug, Deserialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(serde::Serialize, terrace_config::schema::Describe)
+)]
 pub struct DiscordConfig {
-    /// The webhook to post to. Secret: it is a bearer credential — anyone holding it can post
-    /// to the channel — so it stays wrapped from the layer that read it to the request that
-    /// uses it.
+    /// Discord webhook the offers are posted to.
+    ///
+    /// Secret: it is a bearer credential — anyone holding it can post to the channel — so it
+    /// stays wrapped from the layer that read it to the request that uses it. `SecretString`
+    /// refuses to implement `Serialize` for that reason, which is why the field is skipped on
+    /// the way out; the key keeps its row and its `secret` flag either way, and a required key
+    /// has no default to print.
+    #[serde(skip_serializing)]
+    #[cfg_attr(feature = "config-schema", config(secret))]
     pub webhook_url: SecretString,
 }
 
 /// How often the RSS feeds are polled.
 #[derive(Debug, Deserialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(serde::Serialize, terrace_config::schema::Describe)
+)]
 pub struct FeedConfig {
-    /// Seconds between two feed checks. Spelled in seconds rather than as a [`Duration`] so
-    /// the TOML and the environment layer agree on one representation.
+    /// Seconds between two RSS feed checks.
+    ///
+    /// Spelled in seconds rather than as a [`Duration`] so the TOML and the environment layer
+    /// agree on one representation.
     check_interval_secs: u64,
 }
 
@@ -82,8 +160,14 @@ impl FeedConfig {
 /// Where the Prometheus exporter listens.
 #[derive(Debug, Deserialize)]
 #[serde(default)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(serde::Serialize, terrace_config::schema::Describe)
+)]
 pub struct MetricsConfig {
+    /// Address the Prometheus exporter binds. `0.0.0.0` to reach it from outside the container.
     pub ip: IpAddr,
+    /// Port the Prometheus exporter listens on.
     pub port: u16,
 }
 
@@ -107,13 +191,29 @@ impl MetricsConfig {
 /// Logging and error reporting.
 #[derive(Debug, Deserialize)]
 #[serde(default)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(serde::Serialize, terrace_config::schema::Describe)
+)]
 pub struct TelemetryConfig {
-    /// The maximum verbosity that reaches stdout, parsed at boot so an unusable value fails
-    /// the load rather than the first log line.
-    #[serde(deserialize_with = "deserialize_level")]
+    /// The maximum verbosity that reaches stdout: `TRACE`, `DEBUG`, `INFO`, `WARN` or `ERROR`,
+    /// in any case.
+    ///
+    /// Parsed at boot so an unusable value fails the load rather than the first log line.
+    /// `DEBUG` and `TRACE` additionally print which layer supplied each configuration key.
+    #[serde(
+        deserialize_with = "deserialize_level",
+        serialize_with = "serialize_level"
+    )]
     pub log_level: Level,
-    /// Sentry DSN. Absent disables Sentry entirely. Secret: a DSN is a write credential for
-    /// the project's event stream.
+    /// Sentry DSN. Unset disables Sentry entirely.
+    ///
+    /// Secret: a DSN is a write credential for the project's event stream, and skipped on the
+    /// way out for the reason [`DiscordConfig::webhook_url`] is. The key still reports itself
+    /// as unset by default, which is the whole of what a table can usefully say about an
+    /// optional secret.
+    #[serde(skip_serializing)]
+    #[cfg_attr(feature = "config-schema", config(secret))]
     pub sentry_dsn: Option<SecretString>,
 }
 
@@ -140,4 +240,17 @@ where
             "invalid log level `{raw}`, expected one of TRACE, DEBUG, INFO, WARN, ERROR"
         ))
     })
+}
+
+/// Render a [`Level`] the way every layer spells it.
+///
+/// The inverse of [`deserialize_level`], and reachable only from the schema generator: nothing
+/// in this process serialises a `Config`, and `tracing::Level` has no `Serialize` impl of its
+/// own for either of them to use.
+#[cfg(feature = "config-schema")]
+fn serialize_level<S>(level: &Level, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(level.as_str())
 }

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -4,9 +4,15 @@
 //! provider, the `_FILE` indirection and the shadow-key rejection — belongs to
 //! `terrace-config`. What stays here is the one thing that is ours: which environment names
 //! this deployment spells.
+//!
+//! Everything below goes through [`terrace`], so the loader that boots the process, the report
+//! that explains it and the schema the README is generated from are the same dialect by
+//! construction. A generator built over a second [`Terrace`] would document variables the
+//! process does not read.
 
 use serde::de::DeserializeOwned;
 use terrace_config::Terrace;
+use terrace_config::explain::Explanation;
 
 pub use terrace_config::Error as ConfigError;
 
@@ -24,11 +30,16 @@ const PREFIX: &str = "NETCUP_OFFER_BOT_";
 /// rotated in a mounted `Secret`.
 ///
 /// Both variable names below are literals even though `Terrace::new(PREFIX)` derives exactly
-/// these: the README documents them, and a name that exists only as a derivation inside a
-/// dependency is one no line of documentation can be held to. Nothing is reserved — this
-/// process reads no configuration key straight from the environment, so every key is one a
-/// file may supply.
-fn terrace() -> Terrace {
+/// these: naming them here is what puts them in the generated documentation table as the
+/// deployment's own, rather than as a default a dependency happens to hold. Nothing is
+/// reserved — this process reads no configuration key straight from the environment, so every
+/// key is one a file may supply.
+///
+/// Public because the tests build their sandbox over it — `testing::Harness::over` derives
+/// every name it writes from the loader it is handed, so a test cannot go on asserting a
+/// variable this function has stopped naming.
+#[must_use]
+pub fn terrace() -> Terrace {
     Terrace::new(PREFIX)
         .config_var("NETCUP_OFFER_BOT_CONFIG")
         .secrets_dir_var("NETCUP_OFFER_BOT_SECRETS_DIR")
@@ -42,4 +53,27 @@ fn terrace() -> Terrace {
 /// three layers.
 pub fn load<T: DeserializeOwned>() -> Result<T, ConfigError> {
     terrace().load()
+}
+
+/// Which layer supplied each key, re-read at the moment it is called.
+///
+/// Holds no configuration value — not redacted on the way out, never recorded — so the report
+/// is safe to log in full. It is what answers "the `Secret` is mounted and the bot is still
+/// posting to the old webhook": the mount is listed, and so is the stale environment variable
+/// sitting on top of it.
+///
+/// # Errors
+/// Returns [`ConfigError`] if a layer cannot be read at all — an unreadable secrets directory,
+/// or TOML that does not parse.
+pub fn explain() -> Result<Explanation, ConfigError> {
+    terrace().explain()
+}
+
+/// The configuration surface as a schema, for the documentation job.
+///
+/// Reads nothing from the environment, so it produces the same answer on a runner where none
+/// of the variables it describes are set.
+#[cfg(feature = "config-schema")]
+pub fn schema<T: terrace_config::schema::Describe + ?Sized>() -> terrace_config::schema::Schema {
+    terrace().schema::<T>()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ extern crate tracing;
 
 use netcup_offer_bot::FeedChecker;
 use netcup_offer_bot::Result;
-use netcup_offer_bot::config::Config;
+use netcup_offer_bot::config::{self, Config};
 use secrecy::{ExposeSecret, SecretString};
 use sentry::ClientInitGuard;
 use std::net::SocketAddr;
@@ -22,6 +22,8 @@ async fn main() -> Result<()> {
     let config = Config::load()?;
 
     setup_tracing(config.telemetry.log_level);
+
+    log_configuration_layers(config.telemetry.log_level);
 
     // Prevents the process from exiting until all events are sent
     let _sentry = setup_sentry(config.telemetry.sentry_dsn.as_ref());
@@ -43,6 +45,27 @@ fn setup_tracing(level: tracing::Level) {
         .with(tracing_subscriber::fmt::layer().with_filter(filter::LevelFilter::from_level(level)))
         .with(sentry::integrations::tracing::layer().with_filter(filter::LevelFilter::DEBUG))
         .init();
+}
+
+/// Report which layer supplied each configuration key.
+///
+/// The answer to "the `Secret` is mounted and the bot is still posting to the old webhook": the
+/// mount is listed, and so is the stale environment variable sitting on top of it. The report
+/// holds no configuration value — never recorded, rather than redacted on the way out — so
+/// there is nothing in it a log should not have.
+///
+/// Assembled only at the levels that would print it, because it re-reads every layer to build
+/// it. A failure is not fatal: the process has already loaded the configuration it needs, and
+/// losing the explanation of it is not a reason to refuse to start.
+fn log_configuration_layers(level: tracing::Level) {
+    if level < tracing::Level::DEBUG {
+        return;
+    }
+
+    match config::explain() {
+        Ok(layers) => debug!("Configuration layers:\n{}", layers),
+        Err(e) => warn!("Could not explain the configuration layers: {}", e),
+    }
 }
 
 fn setup_sentry(dsn: Option<&SecretString>) -> Option<ClientInitGuard> {

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -5,42 +5,46 @@
 //! `README.md` — which is why the expected values below are literals rather than references to
 //! the constants that produce them.
 //!
-//! These live in a test binary of their own rather than beside the code, because
-//! [`figment::Jail`] manipulates the *process* environment: `clear_env` unsets `TMP` along with
-//! everything else, and a `tempfile` call on another test thread then has nowhere to write. A
-//! separate binary is a separate process, so the isolation is real rather than a convention
-//! future tests have to remember.
+//! Every name is derived from [`config::terrace`] rather than spelled out, because the harness
+//! is built over the loader the process itself boots through. A test that wrote
+//! `NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL_FILE` by hand would keep passing after the loader
+//! stopped reading it, while testing a variable nothing sets.
+//!
+//! These live in a test binary of their own rather than beside the code, because the harness
+//! manipulates the *process* environment: it starts each jail with an empty one, which unsets
+//! `TMP` along with everything else, and a `tempfile` call on another test thread then has
+//! nowhere to write. A separate binary is a separate process, so the isolation is real rather
+//! than a convention future tests have to remember.
 
-// Every test body is a closure passed to `Jail::expect_with`, which fixes the error type to the
-// large `figment::Error`. Nothing here can box it, and no `Err` is ever constructed on a hot
-// path.
-#![expect(
-    clippy::result_large_err,
-    reason = "figment::Jail::expect_with fixes the closure's error type"
-)]
-
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::time::Duration;
 
-use netcup_offer_bot::config::Config;
+use netcup_offer_bot::config::{self, Config};
 use secrecy::ExposeSecret;
+use terrace_config::testing::Harness;
 use tracing::Level;
 
 const WEB_HOOK: &str = "https://discord.com/api/webhooks/";
-const ENV_WEB_HOOK: &str = "NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL";
-const ENV_CHECK_INTERVAL: &str = "NETCUP_OFFER_BOT_FEED__CHECK_INTERVAL_SECS";
-const ENV_SECRETS_DIR: &str = "NETCUP_OFFER_BOT_SECRETS_DIR";
+
+/// The keys, as the loader spells them. Every layer derives its own spelling from these, so a
+/// test names a key once and the harness decides whether that means a variable or a file.
+const WEBHOOK_KEY: &str = "discord.webhook_url";
+const CHECK_INTERVAL_KEY: &str = "feed.check_interval_secs";
+
+/// A sandbox over the loader this crate actually boots through.
+fn harness() -> Harness {
+    Harness::over(config::terrace())
+}
 
 /// The required keys and nothing else: what an operator has to set, plus every default that
 /// fills in around it.
 #[test]
 fn env_supplies_required_keys_and_defaults_fill_the_rest() {
-    figment::Jail::expect_with(|jail| {
-        jail.clear_env();
-        jail.set_env(ENV_WEB_HOOK, WEB_HOOK);
-        jail.set_env(ENV_CHECK_INTERVAL, "42");
+    harness().run(|jail| {
+        jail.env_key(WEBHOOK_KEY, WEB_HOOK);
+        jail.env_key(CHECK_INTERVAL_KEY, 42);
 
-        let config = Config::load().map_err(|e| e.to_string()).unwrap();
+        let config: Config = jail.load()?;
         assert_eq!(config.discord.webhook_url.expose_secret(), WEB_HOOK);
         assert_eq!(config.feed.check_interval(), Duration::from_secs(42));
         assert_eq!(
@@ -56,16 +60,15 @@ fn env_supplies_required_keys_and_defaults_fill_the_rest() {
 /// Every optional block, set through the environment.
 #[test]
 fn env_overrides_every_default() {
-    figment::Jail::expect_with(|jail| {
-        jail.clear_env();
-        jail.set_env(ENV_WEB_HOOK, WEB_HOOK);
-        jail.set_env(ENV_CHECK_INTERVAL, "42");
-        jail.set_env("NETCUP_OFFER_BOT_METRICS__IP", "0.0.0.0");
-        jail.set_env("NETCUP_OFFER_BOT_METRICS__PORT", "9999");
-        jail.set_env("NETCUP_OFFER_BOT_TELEMETRY__LOG_LEVEL", "debug");
-        jail.set_env("NETCUP_OFFER_BOT_TELEMETRY__SENTRY_DSN", "https://sentry/1");
+    harness().run(|jail| {
+        jail.env_key(WEBHOOK_KEY, WEB_HOOK);
+        jail.env_key(CHECK_INTERVAL_KEY, 42);
+        jail.env_key("metrics.ip", "0.0.0.0");
+        jail.env_key("metrics.port", 9999);
+        jail.env_key("telemetry.log_level", "debug");
+        jail.env_key("telemetry.sentry_dsn", "https://sentry/1");
 
-        let config = Config::load().map_err(|e| e.to_string()).unwrap();
+        let config: Config = jail.load()?;
         assert_eq!(
             config.metrics.socket(),
             "0.0.0.0:9999".parse::<SocketAddr>().unwrap()
@@ -81,11 +84,14 @@ fn env_overrides_every_default() {
 
 /// The TOML layer alone is enough to boot, and `./config.toml` is found with nothing pointing
 /// at it.
+///
+/// Written with `jail.write` rather than `jail.config`, which is the one place in this file
+/// where deriving the name would test the wrong thing: `jail.config` sets
+/// `$NETCUP_OFFER_BOT_CONFIG` as well, and the default path is exactly what is under test.
 #[test]
 fn a_toml_file_supplies_the_whole_configuration() {
-    figment::Jail::expect_with(|jail| {
-        jail.clear_env();
-        jail.create_file(
+    harness().run(|jail| {
+        jail.write(
             "config.toml",
             "[discord]\n\
              webhook_url = \"https://discord.com/api/webhooks/toml\"\n\
@@ -95,7 +101,7 @@ fn a_toml_file_supplies_the_whole_configuration() {
              port = 1234\n",
         )?;
 
-        let config = Config::load().map_err(|e| e.to_string()).unwrap();
+        let config: Config = jail.load()?;
         assert_eq!(
             config.discord.webhook_url.expose_secret(),
             "https://discord.com/api/webhooks/toml"
@@ -103,10 +109,7 @@ fn a_toml_file_supplies_the_whole_configuration() {
         assert_eq!(config.feed.check_interval(), Duration::from_secs(180));
         assert_eq!(config.metrics.port, 1234);
         // An untouched sibling of an overridden key still defaults.
-        assert_eq!(
-            config.metrics.ip,
-            "127.0.0.1".parse::<std::net::IpAddr>().unwrap()
-        );
+        assert_eq!(config.metrics.ip, "127.0.0.1".parse::<IpAddr>().unwrap());
         Ok(())
     });
 }
@@ -115,20 +118,40 @@ fn a_toml_file_supplies_the_whole_configuration() {
 /// a `ConfigMap`'s TOML cannot win over the real webhook.
 #[test]
 fn a_secrets_directory_outranks_the_toml_layer() {
-    figment::Jail::expect_with(|jail| {
-        jail.clear_env();
-        jail.create_file(
-            "config.toml",
+    harness().run(|jail| {
+        jail.config(
             "[discord]\n\
              webhook_url = \"https://discord.com/api/webhooks/placeholder\"\n\
              [feed]\n\
              check_interval_secs = 180\n",
         )?;
-        jail.create_dir("secrets")?;
-        jail.create_file("secrets/discord__webhook_url", WEB_HOOK)?;
-        jail.set_env(ENV_SECRETS_DIR, jail.directory().join("secrets").display());
+        jail.secret_key(WEBHOOK_KEY, WEB_HOOK)?;
 
-        let config = Config::load().map_err(|e| e.to_string()).unwrap();
+        let config: Config = jail.load()?;
+        assert_eq!(config.discord.webhook_url.expose_secret(), WEB_HOOK);
+        Ok(())
+    });
+}
+
+/// The mount as the kubelet actually writes it, rather than as a directory of plain files.
+///
+/// The keys are symlinks into `..data`, which is itself a symlink to a timestamped generation
+/// directory. `DirEntry::metadata()` does not follow symlinks, so a provider that asks it
+/// whether an entry is a file reports every real key as "not a file" and the service boots on
+/// compiled defaults with no error anywhere — silently posting nothing, in this deployment's
+/// case. Only this layout reproduces that, which is why it is a test and not a variant of the
+/// one above.
+#[test]
+#[cfg(unix)]
+fn a_projected_secret_volume_supplies_the_webhook() {
+    harness().run(|jail| {
+        jail.env_key(CHECK_INTERVAL_KEY, 42);
+        jail.secrets_volume()
+            .file("discord__webhook_url", WEB_HOOK)
+            .symlinked()
+            .create()?;
+
+        let config: Config = jail.load()?;
         assert_eq!(config.discord.webhook_url.expose_secret(), WEB_HOOK);
         Ok(())
     });
@@ -138,16 +161,11 @@ fn a_secrets_directory_outranks_the_toml_layer() {
 /// directory of them.
 #[test]
 fn file_indirection_supplies_a_single_key() {
-    figment::Jail::expect_with(|jail| {
-        jail.clear_env();
-        jail.set_env(ENV_CHECK_INTERVAL, "42");
-        jail.create_file("webhook", WEB_HOOK)?;
-        jail.set_env(
-            "NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL_FILE",
-            jail.directory().join("webhook").display(),
-        );
+    harness().run(|jail| {
+        jail.env_key(CHECK_INTERVAL_KEY, 42);
+        jail.indirection(WEBHOOK_KEY, WEB_HOOK)?;
 
-        let config = Config::load().map_err(|e| e.to_string()).unwrap();
+        let config: Config = jail.load()?;
         assert_eq!(config.discord.webhook_url.expose_secret(), WEB_HOOK);
         Ok(())
     });
@@ -158,18 +176,47 @@ fn file_indirection_supplies_a_single_key() {
 /// would otherwise keep the process posting to a webhook that has since been rotated.
 #[test]
 fn a_key_supplied_twice_is_refused() {
-    figment::Jail::expect_with(|jail| {
-        jail.clear_env();
-        jail.set_env(ENV_WEB_HOOK, WEB_HOOK);
-        jail.set_env(ENV_CHECK_INTERVAL, "42");
-        jail.create_dir("secrets")?;
-        jail.create_file("secrets/discord__webhook_url", "https://rotated/hook")?;
-        jail.set_env(ENV_SECRETS_DIR, jail.directory().join("secrets").display());
+    harness().run(|jail| {
+        jail.env_key(WEBHOOK_KEY, WEB_HOOK);
+        jail.env_key(CHECK_INTERVAL_KEY, 42);
+        jail.secret_key(WEBHOOK_KEY, "https://rotated/hook")?;
 
-        let error = Config::load().expect_err("two sources define discord.webhook_url");
+        let error = jail
+            .load::<Config>()
+            .expect_err("two sources define discord.webhook_url");
         assert!(
-            error.to_string().contains("discord.webhook_url"),
+            error.to_string().contains(WEBHOOK_KEY),
             "the error must name the key: {error}"
+        );
+        Ok(())
+    });
+}
+
+/// The report an operator reads when the mount is in place and the old webhook is still being
+/// posted to.
+///
+/// It names the layer, which is the half a value assertion cannot make: a `secret_key` that a
+/// forgotten `env_key` is shadowing loads perfectly well and pins nothing.
+#[test]
+fn the_explanation_names_the_layer_that_supplied_the_webhook() {
+    harness().run(|jail| {
+        jail.env_key(CHECK_INTERVAL_KEY, 42);
+        jail.secret_key(WEBHOOK_KEY, WEB_HOOK)?;
+
+        let explanation = jail.explain()?;
+        let origin = explanation
+            .origin(WEBHOOK_KEY)
+            .expect("the mounted key is reported");
+        assert!(
+            matches!(
+                origin.effective(),
+                terrace_config::explain::Layer::SecretsFile(_)
+            ),
+            "the mount has to be the effective layer: {origin:?}"
+        );
+        assert!(
+            origin.shadowed().is_empty(),
+            "nothing shadows it: {origin:?}"
         );
         Ok(())
     });
@@ -177,49 +224,45 @@ fn a_key_supplied_twice_is_refused() {
 
 #[test]
 fn a_missing_required_key_fails_the_load() {
-    figment::Jail::expect_with(|jail| {
-        jail.clear_env();
-        jail.set_env(ENV_CHECK_INTERVAL, "42");
+    harness().run(|jail| {
+        jail.env_key(CHECK_INTERVAL_KEY, 42);
 
-        assert!(Config::load().is_err());
+        assert!(jail.load::<Config>().is_err());
         Ok(())
     });
 }
 
 #[test]
 fn an_unparsable_check_interval_fails_the_load() {
-    figment::Jail::expect_with(|jail| {
-        jail.clear_env();
-        jail.set_env(ENV_WEB_HOOK, WEB_HOOK);
-        jail.set_env(ENV_CHECK_INTERVAL, "soon");
+    harness().run(|jail| {
+        jail.env_key(WEBHOOK_KEY, WEB_HOOK);
+        jail.env_key(CHECK_INTERVAL_KEY, "soon");
 
-        assert!(Config::load().is_err());
+        assert!(jail.load::<Config>().is_err());
         Ok(())
     });
 }
 
 #[test]
 fn an_unparsable_metric_ip_fails_the_load() {
-    figment::Jail::expect_with(|jail| {
-        jail.clear_env();
-        jail.set_env(ENV_WEB_HOOK, WEB_HOOK);
-        jail.set_env(ENV_CHECK_INTERVAL, "42");
-        jail.set_env("NETCUP_OFFER_BOT_METRICS__IP", "abcde");
+    harness().run(|jail| {
+        jail.env_key(WEBHOOK_KEY, WEB_HOOK);
+        jail.env_key(CHECK_INTERVAL_KEY, 42);
+        jail.env_key("metrics.ip", "abcde");
 
-        assert!(Config::load().is_err());
+        assert!(jail.load::<Config>().is_err());
         Ok(())
     });
 }
 
 #[test]
 fn an_unparsable_metric_port_fails_the_load() {
-    figment::Jail::expect_with(|jail| {
-        jail.clear_env();
-        jail.set_env(ENV_WEB_HOOK, WEB_HOOK);
-        jail.set_env(ENV_CHECK_INTERVAL, "42");
-        jail.set_env("NETCUP_OFFER_BOT_METRICS__PORT", "abcde");
+    harness().run(|jail| {
+        jail.env_key(WEBHOOK_KEY, WEB_HOOK);
+        jail.env_key(CHECK_INTERVAL_KEY, 42);
+        jail.env_key("metrics.port", "abcde");
 
-        assert!(Config::load().is_err());
+        assert!(jail.load::<Config>().is_err());
         Ok(())
     });
 }
@@ -228,13 +271,14 @@ fn an_unparsable_metric_port_fails_the_load() {
 /// so the error has to name the value and the accepted set rather than read as "invalid level".
 #[test]
 fn an_unknown_log_level_names_the_accepted_set() {
-    figment::Jail::expect_with(|jail| {
-        jail.clear_env();
-        jail.set_env(ENV_WEB_HOOK, WEB_HOOK);
-        jail.set_env(ENV_CHECK_INTERVAL, "42");
-        jail.set_env("NETCUP_OFFER_BOT_TELEMETRY__LOG_LEVEL", "FATAL");
+    harness().run(|jail| {
+        jail.env_key(WEBHOOK_KEY, WEB_HOOK);
+        jail.env_key(CHECK_INTERVAL_KEY, 42);
+        jail.env_key("telemetry.log_level", "FATAL");
 
-        let error = Config::load().expect_err("FATAL is not a tracing level");
+        let error = jail
+            .load::<Config>()
+            .expect_err("FATAL is not a tracing level");
         let message = error.to_string();
         assert!(message.contains("FATAL"), "must name the value: {message}");
         assert!(message.contains("TRACE"), "must name the set: {message}");


### PR DESCRIPTION
Updates `terrace-config` from `v0.2.0` to `v0.5.0`, adopts the three add-on features it
introduces where each pays for itself, and replaces the hand-maintained configuration reference
in `README.md` with generated output.

## `explain` — on in the container

Costs no dependency at all: a second walk of the layers and the strings that render it. It
answers the one question this deployment actually gets asked — why a webhook mounted from a
`Secret` is not the one being used — so `main` prints it at `DEBUG` and `TRACE`, and a failure to
assemble it is a warning rather than a refusal to boot.

## `testing` — dev-dependencies

`tests/config.rs` is rewritten over `testing::Harness`, and `figment` leaves the
dev-dependencies with it. Every name a test arranges is now derived from the loader the process
itself boots through, so a test cannot go on asserting a variable this crate has stopped reading.

Two tests are new rather than migrated:

- the mount as the kubelet actually writes it — the keys as symlinks through `..data` — which is
  the layout that silently boots a service on compiled defaults;
- an assertion that the *layer* supplying the webhook is the secrets file, which a value
  assertion cannot make: a mounted secret that a leftover environment variable is shadowing
  loads perfectly well and pins nothing.

## `schema` — behind a `config-schema` feature, off in the container

It links `serde_json` and runs a derive over every config struct, which an image that will never
print a table has no reason to carry. `examples/readme-variables.rs` turns it into one line of
strict JSON — the `variables` input of
`TimSchoenle/actions/actions/common/render-template-and-commit@v1.1.3`.

`serde_json` does the escaping, which is why this is a Rust example and not a shell script
assembling JSON with `printf`: a generated Markdown table full of `"`, `\` and newlines survives
the trip through a workflow output verbatim.

## The generator

`README.md` is now rendered from `.github/templates/README.md.hbs`. Everything derivable from the
code is injected: the key table, the loader-variable table and the example `config.toml` come
from the `Config` type, the version the `docker run` examples pin comes from `Cargo.toml`, and
the prefix, nesting separator and `_FILE` suffix come from the loader's own dialect. Adding a key
or changing a default updates the page in the same commit that changes the code.

`.github/workflows/docs.yaml` makes that claim true in both directions:

- on a pull request from this repository it renders and commits the result to the branch, so the
  release-please pull request — the commit that bumps `version` — arrives with the matching
  README;
- on a push to `master`, and on a fork pull request, it re-renders in `check` mode instead,
  writing nothing and failing with the first differing line when the committed file is stale.

Its concurrency group is shared with the `fmt` job in `build.yaml`, which gains a job-level
`concurrency` block here: both commit to the pull request branch through an API that rejects a
commit whose parent has moved, so they queue rather than race.

Three long-standing errors in the page were fixed by generating it: the workflow-status badge
pointed at `build.yml` rather than `build.yaml`, and the licence link pointed at `blob/main/LICENSE.md`
in a repository whose default branch is `master` and whose file is `LICENSE`.

## Verification

`cargo fmt --all --check`, `cargo clippy --all-targets`, and the same with
`--features config-schema`, all clean. `cargo test` and `cargo test --features config-schema`
pass. The committed `README.md` was rendered with the action's own Handlebars configuration —
`noEscape`, `preventIndent`, `strict`, LF — and re-rendering it is byte-identical, so the
`check` job starts green.
