### PR TITLE
feat(config): publish the config contract with the image

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Shell scripts run on Linux runners and inside containers, so their line endings are not the
+# checkout platform's to choose: a CRLF checkout leaves a carriage return on the shebang line
+# and the kernel looks for an interpreter named "bash\r".
+*.sh text eol=lf

--- a/.github/scripts/check-contract-drift.sh
+++ b/.github/scripts/check-contract-drift.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# The reverse gate: regenerate the config contract and the Dockerfile's `LABEL` block, and fail
+# if either has drifted from what is committed.
+#
+#   .github/scripts/check-contract-drift.sh
+#
+# Run from the repository root, with a Rust toolchain on PATH. It rewrites
+# `docs/config.contract.json` in place, so a local run doubles as the fix: inspect the diff,
+# commit it.
+#
+# Why this exists when CI already checks the built image: this catches a renamed key, or a
+# renamed prefix, in the pull request that renamed it — one step earlier than a label check that
+# only runs once an image has been built, and in a diff a reviewer reads rather than in a build
+# log nobody opens. It costs a `cargo run`.
+
+set -euo pipefail
+
+contract=docs/config.contract.json
+
+generate() {
+  cargo run --quiet --features config-schema --example config-contract -- "$@"
+}
+
+status=0
+
+generate --format contract > "${contract}"
+if ! git diff --exit-code --stat -- "${contract}"; then
+  echo "error: ${contract} is stale — the configuration surface changed and the committed" >&2
+  echo "       contract did not. The regenerated file is in your working tree; commit it." >&2
+  echo >&2
+  git --no-pager diff -- "${contract}" >&2
+  status=1
+fi
+
+# The `LABEL` block is the one part of the contract that lives in a second file and cannot be
+# generated into place: a `LABEL` key cannot be interpolated from anything. So it is compared
+# instead.
+#
+# A bash substring test rather than `grep`: with `-z`, GNU grep still splits the *pattern* on
+# newlines, so a three-line block matches an image that carries only the first line — which is
+# precisely the drift this is here to catch. Carriage returns are stripped first, because the
+# generator writes LF and a checkout on Windows may not.
+block=$(generate --format dockerfile)
+dockerfile=$(tr -d '\r' < Dockerfile)
+if [[ "${dockerfile}" != *"${block}"* ]]; then
+  echo "error: the Dockerfile does not carry the generated LABEL block verbatim. Paste this," >&2
+  echo "       replacing the existing 'dev.terrace.config.*' block:" >&2
+  echo >&2
+  printf '%s\n' "${block}" >&2
+  status=1
+fi
+
+if [ "${status}" -eq 0 ]; then
+  echo "The committed contract and the Dockerfile's LABEL block are both current."
+fi
+
+exit "${status}"

--- a/.github/scripts/verify-contract-labels.sh
+++ b/.github/scripts/verify-contract-labels.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# Check that a built image carries the config contract's `dev.terrace.config.*` labels.
+#
+#   verify-contract-labels.sh <labels.json> <contract.labels> <what>
+#
+#     labels.json       the image's labels as a JSON object, however the caller obtained them
+#     contract.labels   `--format labels` from the same generator run that produced the document
+#     what              how to name this image in a failure, e.g. "linux/arm64"
+#
+# This is `Contract::verify_labels` from the other side, and it mirrors it exactly: presence and
+# equality of the labels the generator emitted, and nothing more. Extra labels are ignored on
+# purpose — every image carries `org.opencontainers.image.*` and whatever its base contributed,
+# and none of that is this document's business.
+#
+# It checks the **image**, never the Dockerfile. A source diff cannot see a base image that
+# overrode a label, a `LABEL` line deleted on a branch nobody diffed, or a build argument that
+# silently failed to interpolate. This sees what a registry will actually serve.
+#
+# Two things it refuses rather than passes, because both look like success:
+#
+#   - a labels document that is not a JSON object. `docker inspect` reports `.Config.Labels` and
+#     `crane config` reports `.config.Labels`; reading the wrong one yields `null`, and a
+#     careless comparison treats that as "nothing to compare".
+#   - an empty expectation file. A generator that wrote nothing would otherwise make the loop
+#     below trivially true, which is the one failure this whole scheme cannot afford.
+#
+# Every violation is reported before exiting. A build that names one missing label and hides two
+# is a second round trip.
+
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: $0 <labels.json> <contract.labels> <what>" >&2
+  exit 2
+fi
+
+labels_json=$1
+expected_file=$2
+what=$3
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: ${what}: jq is not on PATH, so no comparison was made. This is not a passing" >&2
+  echo "       image — it is an unrun check." >&2
+  exit 1
+fi
+
+for file in "${labels_json}" "${expected_file}"; do
+  if [ ! -f "${file}" ]; then
+    echo "error: ${what}: ${file} does not exist, so nothing was compared." >&2
+    exit 1
+  fi
+done
+
+if ! jq -e 'type == "object"' "${labels_json}" >/dev/null 2>&1; then
+  echo "error: ${what}: ${labels_json} holds $(jq -r 'type' "${labels_json}" 2>/dev/null || echo 'unparseable JSON'), not an object." >&2
+  echo "       An image with no labels at all reports {}; a null means the wrong JSON path was" >&2
+  echo "       read — 'docker inspect' says .Config.Labels and 'crane config' says .config.Labels." >&2
+  exit 1
+fi
+
+expected_count=$(grep -c '=' "${expected_file}" || true)
+if [ "${expected_count}" -eq 0 ]; then
+  echo "error: ${what}: ${expected_file} declares no labels, so this check would pass for any" >&2
+  echo "       image at all. Regenerate it with '--format labels'." >&2
+  exit 1
+fi
+
+status=0
+while IFS='=' read -r name expected; do
+  [ -n "${name}" ] || continue
+
+  actual=$(jq -r --arg n "${name}" '.[$n] // ""' "${labels_json}")
+  if [ "${actual}" = "${expected}" ]; then
+    continue
+  fi
+
+  if [ -z "${actual}" ]; then
+    echo "error: ${what}: the image carries no '${name}', so nothing can discover this contract" >&2
+    echo "       from its config blob." >&2
+  else
+    echo "error: ${what}: the image's '${name}' is '${actual}', and this contract's is '${expected}'." >&2
+  fi
+  status=1
+done < "${expected_file}"
+
+if [ "${status}" -eq 0 ]; then
+  echo "${what}: ${expected_count} contract labels match the generated document."
+else
+  echo "       'cargo run --features config-schema --example config-contract -- --format dockerfile'" >&2
+  echo "       emits the block the Dockerfile should carry." >&2
+fi
+
+exit "${status}"

--- a/.github/templates/README.md.hbs
+++ b/.github/templates/README.md.hbs
@@ -148,6 +148,40 @@ Or Docker's `{{ indirection_suffix }}` convention, for a single secret:
   -e {{ prefix }}DISCORD{{ nesting_separator }}WEBHOOK_URL{{ indirection_suffix }}="/run/secrets/webhook"
   ```
 
+#### The config contract
+
+Every release publishes the table above as a machine-readable document, so a chart deploying this
+image can be checked against what the image actually reads rather than against a copy of this page
+that may have drifted. The committed copy is [`docs/config.contract.json`](docs/config.contract.json).
+
+Each image carries the same document three ways:
+
+| Carrier | What it answers |
+|---|---|
+| `LABEL dev.terrace.config.*` in the image config blob | Does this image declare a contract, where is its offline copy, and which environment variables are its business — answerable in one registry request, with no layer pull |
+| `/config/contract.json` in the image | The offline copy, for a `docker save` tarball or an air-gapped mirror |
+| An OCI referrer of type `application/vnd.terrace.config-schema.v1+json` on the pushed digest, cosign-signed | The canonical fetch, tied to the exact build a chart pins |
+
+All three are rendered from the same document by one program:
+
+```shell
+cargo run --features config-schema --example config-contract -- --format contract
+cargo run --features config-schema --example config-contract -- --format labels
+cargo run --features config-schema --example config-contract -- --format dockerfile
+```
+
+After changing a configuration key, regenerate the committed copy and the Dockerfile's `LABEL`
+block:
+
+```shell
+.github/scripts/check-contract-drift.sh
+```
+
+It rewrites `docs/config.contract.json` in place and prints the `LABEL` block to paste if it
+changed, so a local run is also the fix. CI runs the same script, and separately checks the built
+**image** — on every platform in the index — against the labels the generator emitted, before
+anything is attached to the digest or signed.
+
 ## License
 
 Distributed under the MIT License. See [LICENSE](https://github.com/{{ repository }}/blob/{{ branch }}/LICENSE)

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -106,6 +106,32 @@ jobs:
         uses: TimSchoenle/actions/actions/rust/clippy@dcfb46a6a17ad8565db74057ce60278953056ad5 # tag=actions-rust-clippy-v1.1.9
 
 
+  # The reverse gate on the config contract: regenerate the committed document and the
+  # Dockerfile's `LABEL` block from the Rust types and fail if either has drifted. A renamed key
+  # or a renamed prefix then shows up in the pull request that renamed it, as a diff a reviewer
+  # reads — one step earlier than the label check on the built image, and far cheaper.
+  #
+  # No toolchain setup: the runner image ships a current stable Rust, and this is a `cargo run`
+  # of one example.
+  config-contract:
+    name: Config Contract
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to checkout the code
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Check the committed contract and the Dockerfile LABEL block
+        run: .github/scripts/check-contract-drift.sh
+
   docker-build-test:
     name: Docker Build and Test (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
@@ -158,6 +184,49 @@ jobs:
             VERSION=test
           cache-from: type=gha,scope=${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+
+      # Exported from the same build graph the image came from, so the generator is not run a
+      # second time at a second moment and the labels cannot describe a different document than
+      # the one in the image. `VERSION` matches the image build's, because it reaches the
+      # document's `app.version` field and the two copies are compared below.
+      - name: Export the config contract
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -euo pipefail
+          docker buildx build \
+            --target contract-export \
+            --platform "${PLATFORM}" \
+            --output "type=local,dest=./contract-out" \
+            --build-arg VERSION=test \
+            .
+
+      # The image, never the Dockerfile. A source diff cannot see a base image that overrode a
+      # label, a `LABEL` line deleted on a branch nobody diffed, or a build argument that
+      # silently failed to interpolate.
+      - name: Verify the image carries the contract labels
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -euo pipefail
+          docker inspect --format '{{json .Config.Labels}}' netcup-offer-bot:test > labels.json
+          .github/scripts/verify-contract-labels.sh labels.json ./contract-out/contract.labels "${PLATFORM}"
+
+      # The cross-check the dropped `sha256` label would have bought. The build is the one place
+      # that holds both copies, so it costs nothing here and is invisible everywhere else — a
+      # stale in-image copy is exactly the failure nothing downstream can see.
+      #
+      # The path comes from the label rather than from a literal, which ties the two together: a
+      # `COPY` that lands the document somewhere the label does not name fails right here. A
+      # `FROM scratch` image has no shell, and `docker cp` does not need one.
+      - name: Verify the in-image contract is the document that was exported
+        run: |
+          set -euo pipefail
+          contract_path="$(jq -r '.["dev.terrace.config.contract.path"]' labels.json)"
+          probe="$(docker create netcup-offer-bot:test)"
+          docker cp "${probe}:${contract_path}" ./from-image.json
+          docker rm "${probe}" > /dev/null
+          cmp ./from-image.json ./contract-out/contract.json
 
       - name: Test Docker image runs
         run: |

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -118,6 +118,31 @@ jobs:
           secrets: |
             sentry_token=${{ secrets.SENTRY_AUTH_TOKEN }}
 
+      # The same build graph the push above used, so the generator runs once per architecture
+      # and BuildKit serves this from the cache it just wrote. `VERSION` is the release tag,
+      # which is what reaches the document's `app.version`; the exported bytes are what get
+      # attached to the digest, so they have to be the bytes that went into the image.
+      - name: Export the config contract
+        env:
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -euo pipefail
+          docker buildx build \
+            --target contract-export \
+            --platform "${PLATFORM}" \
+            --output "type=local,dest=/tmp/contract" \
+            --build-arg "VERSION=${TAG}" \
+            .
+
+      - name: Upload the config contract
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: contract-${{ matrix.arch }}
+          path: /tmp/contract/*
+          if-no-files-found: error
+          retention-days: 1
+
       - name: Export digest
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
@@ -152,8 +177,27 @@ jobs:
         with:
           egress-policy: audit
 
+      # The contract check and the attach step both run from this job, and both read scripts
+      # from the repository.
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      # Reads a specific platform's config blob and filesystem out of a multi-platform index
+      # without pulling it into a daemon that can only hold one architecture at a time.
+      - name: Install Crane
+        uses: imjasonh/setup-crane@feee3b6bb0d4c68370f256a4502498c9227e5c6b # v0.7
+
+      # Pinned by version as well as by commit: the attach below writes to a registry, and which
+      # fallback an OCI 1.0 registry gets — Docker Hub is one — is the client's decision.
+      - name: Install ORAS
+        uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
+        with:
+          version: 1.3.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
@@ -170,6 +214,14 @@ jobs:
           path: /tmp/digests
           pattern: digests-*
           merge-multiple: true
+
+      # Not merged: each architecture's copy stays in its own directory so the step below can
+      # compare them instead of letting one silently overwrite the other.
+      - name: Download the config contracts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: /tmp/contracts
+          pattern: contract-*
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -204,6 +256,90 @@ jobs:
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
           echo "Multi-platform index digest: ${DIGEST}"
 
+      # Every architecture generates the document from one source tree with one set of
+      # arguments, so the copies must be byte-identical. If they are not, which one gets
+      # attached to the index would be arbitrary — so this is a failure, not a tie to break.
+      - name: Reduce the per-architecture contracts to one
+        run: |
+          set -euo pipefail
+
+          canonical=""
+          for dir in /tmp/contracts/contract-*; do
+            [ -d "${dir}" ] || continue
+            if [ -z "${canonical}" ]; then
+              canonical="${dir}"
+              continue
+            fi
+            cmp "${canonical}/contract.json"   "${dir}/contract.json"
+            cmp "${canonical}/contract.labels" "${dir}/contract.labels"
+          done
+
+          if [ -z "${canonical}" ]; then
+            echo "error: no build job exported a config contract, so there is nothing to" >&2
+            echo "       check the pushed image against." >&2
+            exit 1
+          fi
+
+          cp "${canonical}/contract.json"   /tmp/contract.json
+          cp "${canonical}/contract.labels" /tmp/contract.labels
+
+      # The checkpoint everything below rests on. Multi-platform, so it necessarily runs after
+      # the push — `--load` cannot take an index. The floating tag is briefly unverified, which
+      # is acceptable because charts pin digests and nothing is attached or signed until this
+      # passes.
+      #
+      # Every platform, read out of the index rather than out of the build matrix: labels live
+      # in each manifest's own config blob, so one architecture can carry them and another not,
+      # and a list maintained by hand here would be the first thing to go stale. The provenance
+      # and SBOM manifests carry `unknown/unknown` and are not platforms.
+      #
+      # `crane config` reports `.config.Labels`; `docker inspect` reports `.Config.Labels`.
+      # Reading the wrong one yields null, which the script refuses rather than reads as empty.
+      # `--platform` is not optional either: without it, `crane config` against an index does
+      # not fail loudly in every version.
+      - name: Verify the pushed image against its config contract
+        env:
+          DIGEST: ${{ steps.manifest.outputs.digest }}
+        run: |
+          set -euo pipefail
+
+          platforms="$(docker buildx imagetools inspect "${DOCKER_REPO}@${DIGEST}" --format '{{json .Manifest}}' \
+            | jq -r '.manifests[] | select(.platform.os != "unknown") | "\(.platform.os)/\(.platform.architecture)"')"
+
+          if [ -z "${platforms}" ]; then
+            echo "error: ${DIGEST} lists no platforms, so nothing was checked." >&2
+            exit 1
+          fi
+
+          status=0
+          for platform in ${platforms}; do
+            slug="${platform//\//-}"
+
+            crane config --platform "${platform}" "${DOCKER_REPO}@${DIGEST}" \
+              | jq -c '.config.Labels' > "labels.${slug}.json"
+
+            if ! .github/scripts/verify-contract-labels.sh \
+                   "labels.${slug}.json" /tmp/contract.labels "${platform}"; then
+              status=1
+              continue
+            fi
+
+            # The cross-check the dropped `sha256` label would have bought: the copy inside the
+            # image and the bytes about to be attached are one document. The path comes from
+            # the label, so a `COPY` that landed it elsewhere fails here.
+            contract_path="$(jq -r '.["dev.terrace.config.contract.path"]' "labels.${slug}.json")"
+            crane export --platform "${platform}" "${DOCKER_REPO}@${DIGEST}" - \
+              | tar -xO "${contract_path#/}" > "from-image.${slug}.json"
+
+            if ! cmp "from-image.${slug}.json" /tmp/contract.json; then
+              echo "error: ${platform}: the copy at ${contract_path} is not the document being" >&2
+              echo "       attached to this digest." >&2
+              status=1
+            fi
+          done
+
+          exit "${status}"
+
       - name: Sign the images with GitHub OIDC Token
         env:
           TAGS: ${{ steps.meta.outputs.tags }}
@@ -214,6 +350,42 @@ jobs:
             images+="${tag}@${DIGEST} "
           done
           cosign sign --yes ${images}
+
+      # Attached to the digest, not to a tag: the referrer's subject is the exact build a chart
+      # pins, and a tag can be moved. Attached verbatim — the bytes the generator wrote, with
+      # nothing added afterwards. There is no digest field to fill in; the attachment to a
+      # digest *is* the tie between image and document.
+      - name: Attach the config contract to the digest
+        env:
+          DIGEST: ${{ steps.manifest.outputs.digest }}
+        run: |
+          set -euo pipefail
+          oras attach \
+            --artifact-type application/vnd.terrace.config-schema.v1+json \
+            "${DOCKER_REPO}@${DIGEST}" \
+            /tmp/contract.json:application/json
+
+      # Discovered rather than assumed: `oras attach` does not report the referrer's own digest,
+      # and on a registry without the referrers API — Docker Hub — the attachment lands under
+      # the fallback tag scheme, which only a discover call resolves.
+      - name: Sign the config contract with GitHub OIDC Token
+        env:
+          DIGEST: ${{ steps.manifest.outputs.digest }}
+        run: |
+          set -euo pipefail
+
+          referrer="$(oras discover --format json \
+            --artifact-type application/vnd.terrace.config-schema.v1+json \
+            "${DOCKER_REPO}@${DIGEST}" | jq -r '.manifests[0].digest // empty')"
+
+          if [ -z "${referrer}" ]; then
+            echo "error: no config-schema referrer on ${DIGEST}, immediately after attaching" >&2
+            echo "       one. The registry did not keep it, and an unsigned contract is one no" >&2
+            echo "       chart will vendor." >&2
+            exit 1
+          fi
+
+          cosign sign --yes "${DOCKER_REPO}@${referrer}"
 
   sentry-release:
     environment:

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,7 @@ fabric.properties
 # Local configuration layer: `./config.toml` is the default TOML source, so a working copy of
 # it holds the real Discord webhook.
 config.toml
+
+# Host-side export of the container build contract stage:
+#   docker buildx build --target contract-export --output type=local,dest=./contract-out .
+/contract-out/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2183,8 +2183,8 @@ dependencies = [
 
 [[package]]
 name = "terrace-config"
-version = "0.5.0"
-source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.5.0#b47ca70cefaf48484682a0913dbef48ba4eba10c"
+version = "0.6.0"
+source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.6.0#fb37309b70ad1d47edd4c1fd0fb3bea86f0ce6c8"
 dependencies = [
  "figment",
  "serde",
@@ -2196,8 +2196,8 @@ dependencies = [
 
 [[package]]
 name = "terrace-config-macros"
-version = "0.5.0"
-source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.5.0#b47ca70cefaf48484682a0913dbef48ba4eba10c"
+version = "0.6.0"
+source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.6.0#fb37309b70ad1d47edd4c1fd0fb3bea86f0ce6c8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,17 +10,22 @@ path = "src/lib.rs"
 path = "src/main.rs"
 name = "netcup-offer-bot"
 
-# The documentation job, and nothing else. `terrace-config/schema` links `serde_json` and
-# compiles a derive macro over every config struct, which is weight an image that will never
-# print a table has no reason to carry — so the container builds with default features and CI
-# turns this on for the one step that renders the README.
+# The two generators, and nothing else. `terrace-config/schema` links `serde_json` and compiles
+# a derive macro over every config struct, which is weight an image that will never print a table
+# has no reason to carry — so the container's runtime stage builds with default features, and the
+# feature is turned on only by the documentation job and by the builder stage that writes the
+# config contract.
 [features]
 config-schema = ["terrace-config/schema"]
 
-# Declared so `cargo clippy --all-targets --features config-schema` keeps the generator
-# compiling; `required-features` is what keeps it out of every build that does not ask for it.
+# Declared so `cargo clippy --all-targets --features config-schema` keeps the generators
+# compiling; `required-features` is what keeps them out of every build that does not ask for them.
 [[example]]
 name = "readme-variables"
+required-features = ["config-schema"]
+
+[[example]]
+name = "config-contract"
 required-features = ["config-schema"]
 
 [dependencies]
@@ -61,13 +66,13 @@ secrecy = { version = "0.10.3", features = ["serde"] }
 # which the container never enables.
 #
 # Pinned by tag, not branch: `cargo update` cannot then move the dependency silently.
-terrace-config = { git = "https://github.com/TimSchoenle/terrace-config", tag = "v0.5.0", default-features = false, features = ["loader", "explain"] }
+terrace-config = { git = "https://github.com/TimSchoenle/terrace-config", tag = "v0.6.0", default-features = false, features = ["loader", "explain"] }
 
 [dev-dependencies]
 # The same dependency as above with its test harness added, not a second copy: cargo unions the
 # features for test builds. `testing` derives every name it writes from the loader the harness
 # was built over, so a test cannot go on asserting a variable this crate has stopped reading.
-terrace-config = { git = "https://github.com/TimSchoenle/terrace-config", tag = "v0.5.0", default-features = false, features = ["testing"] }
+terrace-config = { git = "https://github.com/TimSchoenle/terrace-config", tag = "v0.6.0", default-features = false, features = ["testing"] }
 tempfile = "=3.27.0"
 serde_test = "=1.0.177"
 wiremock = "=0.6.5"

--- a/Dockerfile
+++ b/Dockerfile
@@ -105,6 +105,57 @@ RUN strip --strip-all /tmp/${BINARY_NAME} && \
       echo "Skipping UPX compression for ${BUILD_TARGET}" ; \
     fi
 
+# The configuration contract, and the labels that make it discoverable.
+#
+# `FROM chef` rather than `FROM builder`: the generator reads the same source tree and wants the
+# same toolchain, but nothing it emits depends on the release binary having linked. Basing it on
+# `builder` would queue a document that takes seconds behind a fat-LTO musl build that takes
+# minutes — and would make the host-side export in CI drag that whole build along with it.
+#
+# Both files come out of one stage, from one source tree, in one build. That is the entire
+# guarantee: the `LABEL` block in `runtime` below is checked against `contract.labels` after the
+# image exists, and a document generated at some other time could disagree with it.
+FROM chef AS contract-builder
+
+ARG EXECUTION_DIRECTORY
+ARG TARGETARCH
+ARG VERSION
+
+COPY . .
+
+# Caches of its own, sharing none of `builder`'s. This stage depends on nothing `builder`
+# produces, so BuildKit runs the two concurrently — and a BuildKit cache mount is `sharing=shared`
+# by default, which put two cargo processes in one `$CARGO_HOME/git` with a `.package-cache` lock
+# each. The result was `failed to clone into … no error`, non-deterministically, on whichever of
+# the two lost. Separate ids remove the contention rather than serialising the two heaviest
+# stages behind `sharing=locked`, and cost nothing in CI, where cache mounts are not exported and
+# start empty either way.
+#
+# The target cache would have had to be separate regardless: this is a host-target debug build of
+# an example and shares no artefacts with a `--release --target *-musl` one.
+#
+# `--version` is passed only when the build was told a release. Absent, the document simply omits
+# the field, which is what keeps the committed copy in `docs/` stable across a version bump and
+# so keeps the drift gate from failing every release pull request.
+RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-contract-${TARGETARCH} \
+    --mount=type=cache,target=/usr/local/cargo/git,id=cargo-git-contract-${TARGETARCH} \
+    --mount=type=cache,target=${EXECUTION_DIRECTORY}/target,id=cargo-target-contract-${TARGETARCH} \
+    sh -eu -c '\
+      mkdir -p /out ; \
+      if [ -n "${VERSION:-}" ] ; then set -- --version "${VERSION}" ; else set -- ; fi ; \
+      cargo run --quiet --features config-schema --example config-contract \
+        -- --format contract "$@" > /out/contract.json ; \
+      cargo run --quiet --features config-schema --example config-contract \
+        -- --format labels   "$@" > /out/contract.labels \
+    '
+
+# The two generated files and nothing else, so `--output type=local` puts them on the host
+# without unpacking the builder's toolchain alongside them.
+#
+#   docker buildx build --target contract-export --output type=local,dest=./contract-out .
+FROM scratch AS contract-export
+COPY --from=contract-builder /out/ /
+
 FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS env
 ARG USER_ID
 
@@ -138,10 +189,28 @@ ARG release=unreleased
 LABEL version=${version} \
       release=${release}
 
+# Emitted verbatim by:
+#
+#   cargo run --features config-schema --example config-contract -- --format dockerfile
+#
+# Pasted, never retyped, and never hand-edited: a `LABEL` key cannot be interpolated from
+# anything, so what makes these trustworthy is not how they were written but that CI compares the
+# built image's config blob against `contract.labels` from the same generator run — on every
+# platform — before anything is attached to the digest or signed.
+LABEL dev.terrace.config.contract.version="1" \
+      dev.terrace.config.contract.path="/config/contract.json" \
+      dev.terrace.config.prefix="NETCUP_OFFER_BOT_"
+
 COPY --from=env /etc/passwd /etc/passwd
 COPY --from=env /etc/group /etc/group
 COPY --from=env /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=env /usr/share/zoneinfo /usr/share/zoneinfo
+
+# The offline copy of the contract, at the path `dev.terrace.config.contract.path` above names.
+# Read by anything holding the image and no registry — `docker save`, `crane export`, an
+# air-gapped mirror. The canonical copy is the OCI referrer attached to the pushed digest; this
+# one costs a few kilobytes and removes the registry from the dependency list.
+COPY --from=contract-builder /out/contract.json /config/contract.json
 
 WORKDIR ${EXECUTION_DIRECTORY}
 COPY --from=builder --chmod=555 /tmp/${BINARY_NAME} ./app

--- a/README.md
+++ b/README.md
@@ -188,6 +188,40 @@ Or Docker's `_FILE` convention, for a single secret:
   -e NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL_FILE="/run/secrets/webhook"
   ```
 
+#### The config contract
+
+Every release publishes the table above as a machine-readable document, so a chart deploying this
+image can be checked against what the image actually reads rather than against a copy of this page
+that may have drifted. The committed copy is [`docs/config.contract.json`](docs/config.contract.json).
+
+Each image carries the same document three ways:
+
+| Carrier | What it answers |
+|---|---|
+| `LABEL dev.terrace.config.*` in the image config blob | Does this image declare a contract, where is its offline copy, and which environment variables are its business — answerable in one registry request, with no layer pull |
+| `/config/contract.json` in the image | The offline copy, for a `docker save` tarball or an air-gapped mirror |
+| An OCI referrer of type `application/vnd.terrace.config-schema.v1+json` on the pushed digest, cosign-signed | The canonical fetch, tied to the exact build a chart pins |
+
+All three are rendered from the same document by one program:
+
+```shell
+cargo run --features config-schema --example config-contract -- --format contract
+cargo run --features config-schema --example config-contract -- --format labels
+cargo run --features config-schema --example config-contract -- --format dockerfile
+```
+
+After changing a configuration key, regenerate the committed copy and the Dockerfile's `LABEL`
+block:
+
+```shell
+.github/scripts/check-contract-drift.sh
+```
+
+It rewrites `docs/config.contract.json` in place and prints the `LABEL` block to paste if it
+changed, so a local run is also the fix. CI runs the same script, and separately checks the built
+**image** — on every platform in the index — against the labels the generator emitted, before
+anything is attached to the digest or signed.
+
 ## License
 
 Distributed under the MIT License. See [LICENSE](https://github.com/TimSchoenle/netcup-offer-bot/blob/master/LICENSE)

--- a/docs/config.contract.json
+++ b/docs/config.contract.json
@@ -1,0 +1,248 @@
+{
+  "terrace_contract": 1,
+  "app": {
+    "name": "netcup-offer-bot",
+    "source": "https://github.com/TimSchoenle/netcup-offer-bot"
+  },
+  "schema": {
+    "schema_version": 1,
+    "dialect": {
+      "prefix": "NETCUP_OFFER_BOT_",
+      "nesting_separator": "__",
+      "indirection_suffix": "_FILE"
+    },
+    "loader": [
+      {
+        "env": "NETCUP_OFFER_BOT_CONFIG",
+        "role": "config",
+        "docs": "Names the TOML layer: a file, or a directory whose `*.toml` files are all merged in name order.",
+        "default": "config.toml"
+      },
+      {
+        "env": "NETCUP_OFFER_BOT_SECRETS_DIR",
+        "role": "secrets_dir",
+        "docs": "Names a directory of key-named files — a mounted Kubernetes `Secret` volume. Each file supplies the key its name spells.",
+        "default": null
+      }
+    ],
+    "keys": [
+      {
+        "path": "discord.webhook_url",
+        "env": "NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL",
+        "env_file": "NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL_FILE",
+        "secrets_file": "discord__webhook_url",
+        "docs": "Discord webhook the offers are posted to.\n\nSecret: it is a bearer credential — anyone holding it can post to the channel — so it\nstays wrapped from the layer that read it to the request that uses it. `SecretString`\nrefuses to implement `Serialize` for that reason, which is why the field is skipped on\nthe way out; the key keeps its row and its `secret` flag either way, and a required key\nhas no default to print.",
+        "ty": "SecretString",
+        "values": [],
+        "constraint": {
+          "type": "string"
+        },
+        "text_form": "text",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": null,
+        "default_value": null,
+        "note": null,
+        "required": true,
+        "secret": true,
+        "reserved": false
+      },
+      {
+        "path": "feed.check_interval_secs",
+        "env": "NETCUP_OFFER_BOT_FEED__CHECK_INTERVAL_SECS",
+        "env_file": "NETCUP_OFFER_BOT_FEED__CHECK_INTERVAL_SECS_FILE",
+        "secrets_file": "feed__check_interval_secs",
+        "docs": "Seconds between two RSS feed checks.\n\nSpelled in seconds rather than as a [`Duration`] so the TOML and the environment layer\nagree on one representation.",
+        "ty": "u64",
+        "values": [],
+        "constraint": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "text_constraint": {
+          "pattern": "^\\s*\\+?[0-9]+\\s*$",
+          "type": "string"
+        },
+        "text_form": "integer",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": null,
+        "default_value": null,
+        "note": null,
+        "required": true,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "metrics.ip",
+        "env": "NETCUP_OFFER_BOT_METRICS__IP",
+        "env_file": "NETCUP_OFFER_BOT_METRICS__IP_FILE",
+        "secrets_file": "metrics__ip",
+        "docs": "Address the Prometheus exporter binds. `0.0.0.0` to reach it from outside the container.",
+        "ty": "IpAddr",
+        "values": [],
+        "constraint": {
+          "type": "string"
+        },
+        "text_form": "unknown",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": "127.0.0.1",
+        "default_value": "127.0.0.1",
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "metrics.port",
+        "env": "NETCUP_OFFER_BOT_METRICS__PORT",
+        "env_file": "NETCUP_OFFER_BOT_METRICS__PORT_FILE",
+        "secrets_file": "metrics__port",
+        "docs": "Port the Prometheus exporter listens on.",
+        "ty": "u16",
+        "values": [],
+        "constraint": {
+          "maximum": 65535,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "text_constraint": {
+          "pattern": "^\\s*\\+?[0-9]+\\s*$",
+          "type": "string"
+        },
+        "text_form": "integer",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": "9184",
+        "default_value": 9184,
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "telemetry.log_level",
+        "env": "NETCUP_OFFER_BOT_TELEMETRY__LOG_LEVEL",
+        "env_file": "NETCUP_OFFER_BOT_TELEMETRY__LOG_LEVEL_FILE",
+        "secrets_file": "telemetry__log_level",
+        "docs": "The maximum verbosity that reaches stdout: `TRACE`, `DEBUG`, `INFO`, `WARN` or `ERROR`,\nin any case.\n\nParsed at boot so an unusable value fails the load rather than the first log line.\n`DEBUG` and `TRACE` additionally print which layer supplied each configuration key.",
+        "ty": "Level",
+        "values": [],
+        "text_form": "unknown",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": "INFO",
+        "default_value": "INFO",
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "telemetry.sentry_dsn",
+        "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY_DSN",
+        "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY_DSN_FILE",
+        "secrets_file": "telemetry__sentry_dsn",
+        "docs": "Sentry DSN. Unset disables Sentry entirely.\n\nSecret: a DSN is a write credential for the project's event stream, and skipped on the\nway out for the reason [`DiscordConfig::webhook_url`] is. The key still reports itself\nas unset by default, which is the whole of what a table can usefully say about an\noptional secret.",
+        "ty": "SecretString",
+        "values": [],
+        "constraint": {
+          "type": "string"
+        },
+        "text_form": "text",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": null,
+        "default_value": null,
+        "note": null,
+        "required": false,
+        "secret": true,
+        "reserved": false
+      }
+    ]
+  },
+  "json_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "properties": {
+      "discord": {
+        "additionalProperties": false,
+        "properties": {
+          "webhook_url": {
+            "description": "Discord webhook the offers are posted to.\n\nSecret: it is a bearer credential — anyone holding it can post to the channel — so it\nstays wrapped from the layer that read it to the request that uses it. `SecretString`\nrefuses to implement `Serialize` for that reason, which is why the field is skipped on\nthe way out; the key keeps its row and its `secret` flag either way, and a required key\nhas no default to print.",
+            "type": "string",
+            "writeOnly": true
+          }
+        },
+        "type": "object"
+      },
+      "feed": {
+        "additionalProperties": false,
+        "properties": {
+          "check_interval_secs": {
+            "description": "Seconds between two RSS feed checks.\n\nSpelled in seconds rather than as a [`Duration`] so the TOML and the environment layer\nagree on one representation.",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "metrics": {
+        "additionalProperties": false,
+        "properties": {
+          "ip": {
+            "default": "127.0.0.1",
+            "description": "Address the Prometheus exporter binds. `0.0.0.0` to reach it from outside the container.",
+            "type": "string"
+          },
+          "port": {
+            "default": 9184,
+            "description": "Port the Prometheus exporter listens on.",
+            "maximum": 65535,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "telemetry": {
+        "additionalProperties": false,
+        "properties": {
+          "log_level": {
+            "default": "INFO",
+            "description": "The maximum verbosity that reaches stdout: `TRACE`, `DEBUG`, `INFO`, `WARN` or `ERROR`,\nin any case.\n\nParsed at boot so an unusable value fails the load rather than the first log line.\n`DEBUG` and `TRACE` additionally print which layer supplied each configuration key."
+          },
+          "sentry_dsn": {
+            "description": "Sentry DSN. Unset disables Sentry entirely.\n\nSecret: a DSN is a write credential for the project's event stream, and skipped on the\nway out for the reason [`DiscordConfig::webhook_url`] is. The key still reports itself\nas unset by default, which is the whole of what a table can usefully say about an\noptional secret.",
+            "type": "string",
+            "writeOnly": true
+          }
+        },
+        "type": "object"
+      }
+    },
+    "title": "netcup-offer-bot configuration",
+    "type": "object"
+  },
+  "external": {
+    "env": [],
+    "ignore": [
+      "KUBERNETES_*",
+      "HOSTNAME"
+    ],
+    "unknown": "reject"
+  }
+}

--- a/examples/config-contract.rs
+++ b/examples/config-contract.rs
@@ -1,0 +1,165 @@
+//! Emit the config contract, and the image labels that make it discoverable.
+//!
+//! ```text
+//! cargo run --quiet --features config-schema --example config-contract -- --format contract    > docs/config.contract.json
+//! cargo run --quiet --features config-schema --example config-contract -- --format labels      > contract.labels
+//! cargo run --quiet --features config-schema --example config-contract -- --format dockerfile  # paste into the Dockerfile
+//! ```
+//!
+//! Three renderings of one document, which is the point: the container build runs this twice in
+//! a single stage — once for the contract and once for the labels — so the labels an image
+//! carries and the document it publishes cannot describe different configurations. The
+//! `dockerfile` rendering is the same labels as the `LABEL` instruction to paste, because a
+//! `LABEL` key cannot be interpolated from anything and the block has to be written by hand.
+//!
+//! The sibling `readme-variables` example is the documentation half of the same schema. Neither
+//! duplicates the other: that one renders tables for a human, this one renders a document for a
+//! pipeline.
+//!
+//! This file is a command line and nothing else. The document is built by
+//! [`netcup_offer_bot::config::contract`], which is in the library so that it can be tested.
+//!
+//! # Nothing is read from the environment
+//!
+//! Every rendering is a function of the source tree and the flags below, so this produces the
+//! same bytes on a developer's machine, in a documentation job and in a container build. That is
+//! what lets CI regenerate the committed `docs/config.contract.json` and diff it.
+//!
+//! # Why the release is a flag
+//!
+//! `App::version` is spelled the way the image tag spells it — `v2.0.1`, not `2.0.1` — and it is
+//! **not** derived from `CARGO_PKG_VERSION`. It would go stale the moment release-please opened a
+//! pull request bumping `Cargo.toml`: the committed contract would still name the old release and
+//! the drift gate would fail the release pull request itself, every release, over a field that
+//! has nothing to do with the configuration surface. Passing it leaves the container build as the
+//! only place that states a release, which is the only place that knows one.
+//!
+//! `--revision` and `--created` are absent by default for a related reason: both make the
+//! document non-reproducible across rebuilds of one commit.
+
+use std::process::ExitCode;
+
+use netcup_offer_bot::config::ConfigError;
+use netcup_offer_bot::config::contract;
+use terrace_config::schema::{Contract, DEFAULT_PATH};
+
+fn main() -> ExitCode {
+    let options = match Options::from_args() {
+        Ok(options) => options,
+        Err(message) => {
+            eprintln!("config-contract: {message}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match render(&options) {
+        Ok(rendered) => {
+            println!("{rendered}");
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("config-contract: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn render(options: &Options) -> Result<String, ConfigError> {
+    let contract = contract(options)?;
+
+    Ok(match options.format {
+        Format::Contract => contract.to_json()?,
+        Format::Labels => contract
+            .labels(DEFAULT_PATH)
+            .into_iter()
+            .map(|(name, value)| format!("{name}={value}"))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        Format::Dockerfile => contract
+            .to_dockerfile_labels(DEFAULT_PATH)
+            .trim_end()
+            .to_owned(),
+    })
+}
+
+/// The contract, with whatever this build was told about itself.
+fn contract(options: &Options) -> Result<Contract, ConfigError> {
+    let mut app = contract::app();
+    if let Some(version) = &options.version {
+        app = app.version(version);
+    }
+    if let Some(revision) = &options.revision {
+        app = app.revision(revision);
+    }
+    if let Some(created) = &options.created {
+        app = app.created(created);
+    }
+    contract::contract(app)
+}
+
+/// What to emit, and what this build knows about itself.
+struct Options {
+    format: Format,
+    /// The release this build is of, spelled as the image tag spells it.
+    version: Option<String>,
+    /// The commit this build is of.
+    revision: Option<String>,
+    /// When this build happened, RFC 3339.
+    created: Option<String>,
+}
+
+/// Which rendering to emit.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Format {
+    /// The document the build embeds in its image and attaches to its digest.
+    Contract,
+    /// The image labels that make that document discoverable, one `NAME=value` per line.
+    Labels,
+    /// The same labels as the `LABEL` instruction to paste into the Dockerfile.
+    Dockerfile,
+}
+
+impl Options {
+    /// The contract itself, unless asked otherwise.
+    fn from_args() -> Result<Self, String> {
+        let mut options = Self {
+            format: Format::Contract,
+            version: None,
+            revision: None,
+            created: None,
+        };
+
+        let mut args = std::env::args().skip(1);
+        while let Some(flag) = args.next() {
+            match flag.as_str() {
+                "--format" => {
+                    options.format = match args.next().as_deref() {
+                        Some("contract") => Format::Contract,
+                        Some("labels") => Format::Labels,
+                        Some("dockerfile") => Format::Dockerfile,
+                        Some(other) => return Err(format!("unknown format `{other}`; {USAGE}")),
+                        None => return Err(format!("--format takes a value; {USAGE}")),
+                    };
+                }
+                "--version" => options.version = Some(value(&mut args, "--version takes a tag")?),
+                "--revision" => {
+                    options.revision = Some(value(&mut args, "--revision takes a commit")?);
+                }
+                "--created" => {
+                    options.created = Some(value(&mut args, "--created takes a timestamp")?);
+                }
+                other => return Err(format!("unknown argument `{other}`; {USAGE}")),
+            }
+        }
+
+        Ok(options)
+    }
+}
+
+/// The next argument, or the caller's own message for why it had to be there.
+fn value(args: &mut impl Iterator<Item = String>, expected: &str) -> Result<String, String> {
+    args.next().ok_or_else(|| format!("{expected}; {USAGE}"))
+}
+
+const USAGE: &str = "usage: config-contract [--format contract|labels|dockerfile] \
+                     [--version <tag>] [--revision <commit>] [--created <rfc3339>]";

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,7 +22,17 @@
 //! every environment spelling, every default, and the *first paragraph* of each field's doc
 //! comment. Write that paragraph for an operator setting the value — anything below it stays
 //! here, for whoever reads the type.
+//!
+//! # The contract this image publishes
+//!
+//! Under the same feature, [`contract`] renders these types as the document the container build
+//! embeds in the image and attaches to its pushed digest, and the `dev.terrace.config.*` labels
+//! that make it discoverable. A key added below is a key the deployment side learns about in the
+//! same commit; `docs/config.contract.json` is the committed copy, and CI fails a pull request
+//! that changes one without the other.
 
+#[cfg(feature = "config-schema")]
+pub mod contract;
 mod loader;
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};

--- a/src/config/contract.rs
+++ b/src/config/contract.rs
@@ -1,0 +1,62 @@
+//! The config contract this image publishes.
+//!
+//! The document a chart is validated against: every configuration key in every spelling that can
+//! supply it, the same keys as a JSON Schema, and the surface outside the loader's namespace. It
+//! is built from [`schema`](super::schema), so it describes the [`Config`](super::Config) this
+//! binary deserialises rather than a second account of it — and the three
+//! `dev.terrace.config.*` labels an image carries are rendered from the same [`Contract`], which
+//! is what stops a label from naming a prefix the loader does not read.
+//!
+//! Three carriers, one document. The labels live in the image config blob, so `crane config`
+//! answers "does this image declare a contract" in one request with no layer pull; a copy at
+//! [`DEFAULT_PATH`](terrace_config::schema::DEFAULT_PATH) makes the image self-describing with no
+//! registry at all; and the canonical copy is attached to the pushed digest as an OCI referrer
+//! and signed.
+//!
+//! This lives in the library rather than in `examples/config-contract.rs` because an example
+//! cannot be tested. The example is a command line over it.
+//!
+//! Compiled only under `config-schema`; see the feature's comment in `Cargo.toml`.
+
+use terrace_config::schema::{App, Contract, External};
+
+use super::{ConfigError, schema};
+
+/// The service's name, as its image and its chart name it.
+pub const APP_NAME: &str = "netcup-offer-bot";
+
+/// Where the source lives.
+pub const SOURCE: &str = "https://github.com/TimSchoenle/netcup-offer-bot";
+
+/// Which build a contract describes, before the caller states a release.
+///
+/// The release is the caller's to add, because this crate has no honest answer for it.
+/// `CARGO_PKG_VERSION` looks like one and is not: it would go stale the moment release-please
+/// opened a pull request bumping `Cargo.toml`, so the committed contract would disagree with the
+/// source in exactly the pull request nobody wants to argue with. Only the container build knows
+/// the tag it is being pushed under.
+#[must_use]
+pub fn app() -> App {
+    App::new(APP_NAME).source(SOURCE)
+}
+
+/// The whole contract this image publishes: every configuration key, and everything else it
+/// reads.
+///
+/// The external surface is two ignore patterns and no declared variables, and that is the honest
+/// answer for this image rather than an unfinished list. The chart passes configuration as
+/// files — `NETCUP_OFFER_BOT_CONFIG` and `NETCUP_OFFER_BOT_SECRETS_DIR`, both of which the loader
+/// owns and the schema already describes — and the binary itself reads nothing from the
+/// environment. What is left is what a Kubernetes pod carries whether an image asked for it or
+/// not, which is what [`External::ignore`] is for.
+///
+/// # Errors
+/// Returns [`ConfigError`] if the schema cannot be built, or if the crate refuses the declared
+/// external surface. Neither depends on the machine this runs on: both are bugs in the
+/// annotations on [`Config`](super::Config) or in this function.
+pub fn contract(app: App) -> Result<Contract, ConfigError> {
+    schema()?
+        .into_contract(app)
+        .external(External::new().ignore("KUBERNETES_*").ignore("HOSTNAME"))
+        .build()
+}

--- a/tests/config_contract.rs
+++ b/tests/config_contract.rs
@@ -1,0 +1,182 @@
+//! The config contract, checked against the things it has to agree with.
+//!
+//! The assertions that matter are the two the deployment side depends on: the labels an image
+//! carries must name the prefix the loader actually reads, and the offline copy's path must be
+//! the one the build copies the document to. CI checks both against a *built image*, which is the
+//! check that counts — a Dockerfile is a recipe and an image is what a registry serves. These
+//! check the other half, that what the generator emits is right in the first place, and they do
+//! it without Docker.
+//!
+//! Compiled only under `config-schema`, which is the feature the generator lives behind.
+
+#![cfg(feature = "config-schema")]
+
+use std::collections::BTreeMap;
+
+use netcup_offer_bot::config;
+use netcup_offer_bot::config::contract::{APP_NAME, SOURCE, app, contract};
+use terrace_config::schema::{
+    CONTRACT_VERSION, DEFAULT_PATH, LABEL_PATH, LABEL_PREFIX, LABEL_VERSION,
+};
+
+/// The prefix `src/config/loader.rs` gives the loader. Spelled out rather than imported: a test
+/// that read the constant would pass just as happily after a rename, and stopping a rename from
+/// reaching a deployment unannounced is this document's whole job.
+const PREFIX: &str = "NETCUP_OFFER_BOT_";
+
+#[test]
+fn the_contract_builds() {
+    let contract = contract(app()).expect("the contract should build");
+
+    assert_eq!(contract.terrace_contract, CONTRACT_VERSION);
+    assert_eq!(contract.app.name, APP_NAME);
+    assert_eq!(contract.app.source.as_deref(), Some(SOURCE));
+    // No release unless the caller states one. See the module docs on `config::contract::app`.
+    assert_eq!(contract.app.version, None);
+}
+
+/// The agreement the chart repository checks from the other side: the image's `prefix` label must
+/// equal the document's own `schema.dialect.prefix`. Rendering both from one [`Contract`] is what
+/// makes that true, and this is the assertion that says so.
+#[test]
+fn the_labels_agree_with_the_document() {
+    let contract = contract(app()).expect("the contract should build");
+    let labels: BTreeMap<String, String> = contract
+        .labels(DEFAULT_PATH)
+        .into_iter()
+        .map(|(name, value)| (name.to_owned(), value))
+        .collect();
+
+    assert_eq!(
+        labels.get(LABEL_PREFIX).map(String::as_str),
+        Some(contract.schema.dialect.prefix.as_str())
+    );
+    assert_eq!(labels.get(LABEL_PREFIX).map(String::as_str), Some(PREFIX));
+    assert_eq!(
+        labels.get(LABEL_PATH).map(String::as_str),
+        Some(DEFAULT_PATH)
+    );
+    assert_eq!(
+        labels.get(LABEL_VERSION).map(String::as_str),
+        Some(CONTRACT_VERSION.to_string().as_str())
+    );
+
+    // `verify_labels` is what a consumer runs against a built image. Running it here against the
+    // labels the same contract emitted is not circular — it is the assertion that the generator's
+    // two outputs are two halves of one document.
+    contract
+        .verify_labels(DEFAULT_PATH, &labels)
+        .expect("the emitted labels should satisfy the contract that emitted them");
+}
+
+/// The `Dockerfile` cannot interpolate a `LABEL` key from anything, so the block is written by
+/// hand and checked. CI checks the built image; this checks the recipe, which is where a reviewer
+/// is looking.
+#[test]
+fn the_dockerfile_carries_the_generated_label_block() {
+    let contract = contract(app()).expect("the contract should build");
+    let block = contract.to_dockerfile_labels(DEFAULT_PATH);
+
+    let dockerfile = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/Dockerfile"))
+        .expect("the Dockerfile should be readable")
+        .replace('\r', "");
+
+    assert!(
+        dockerfile.contains(block.trim_end()),
+        "the Dockerfile does not carry the generated LABEL block verbatim. Paste this, replacing \
+         the existing `dev.terrace.config.*` block:\n\n{block}"
+    );
+}
+
+/// The image copies the document to the path its own label names. A `COPY` to anywhere else
+/// leaves the label pointing at nothing, which no consumer can distinguish from an image that
+/// never carried a contract.
+#[test]
+fn the_dockerfile_copies_the_document_to_the_path_the_label_names() {
+    let dockerfile = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/Dockerfile"))
+        .expect("the Dockerfile should be readable")
+        .replace('\r', "");
+
+    assert!(
+        dockerfile.contains(&format!(
+            "COPY --from=contract-builder /out/contract.json {DEFAULT_PATH}"
+        )),
+        "the runtime stage does not copy the contract to {DEFAULT_PATH}"
+    );
+}
+
+/// Every documented key must be reachable from a Kubernetes `Secret` volume as well as from the
+/// environment, because a mounted `Secret` is how the chart supplies the one credential this
+/// process holds.
+#[test]
+fn every_key_has_an_environment_and_a_file_spelling() {
+    let schema = config::schema().expect("the schema should describe");
+
+    assert!(!schema.keys.is_empty(), "the schema describes no keys");
+    for key in &schema.keys {
+        assert!(
+            key.env.is_some(),
+            "`{}` has no environment spelling: {:?}",
+            key.path,
+            key.unreachable
+        );
+        assert!(
+            key.secrets_file.is_some(),
+            "`{}` cannot be supplied by a mounted Secret",
+            key.path
+        );
+    }
+}
+
+/// The credential is marked secret, so nothing downstream renders its value into a document this
+/// build publishes to a registry.
+#[test]
+fn the_webhook_is_secret_and_required_and_carries_no_default() {
+    let schema = config::schema().expect("the schema should describe");
+    let key = schema
+        .keys
+        .iter()
+        .find(|key| key.path == "discord.webhook_url")
+        .expect("`discord.webhook_url` should be described");
+
+    assert!(key.secret, "the webhook is a bearer credential");
+    assert!(key.required, "nothing can post without it");
+    assert_eq!(key.default, None);
+}
+
+/// The defaults published in the document are the ones a process actually falls back to, read out
+/// of the real `Default` implementations. This is also what exercises `serialize_level`, whose
+/// output has to be a string the loader would accept back.
+#[test]
+fn the_published_defaults_are_the_ones_the_process_falls_back_to() {
+    let contract = contract(app()).expect("the contract should build");
+    let default_of = |path: &str| {
+        contract
+            .schema
+            .keys
+            .iter()
+            .find(|key| key.path == path)
+            .unwrap_or_else(|| panic!("`{path}` should be described"))
+            .default
+            .clone()
+    };
+
+    assert_eq!(default_of("metrics.ip").as_deref(), Some("127.0.0.1"));
+    assert_eq!(default_of("metrics.port").as_deref(), Some("9184"));
+    assert_eq!(default_of("telemetry.log_level").as_deref(), Some("INFO"));
+}
+
+/// A pod carries names no image asked for. Declaring them is what lets the contract keep its
+/// default `unknown: reject` policy, which is the whole of the gate on the chart side — reaching
+/// for `warn` instead would give it up to tolerate two.
+#[test]
+fn the_external_surface_accounts_for_what_a_pod_injects() {
+    let contract = contract(app()).expect("the contract should build");
+
+    assert!(
+        contract.external.env.is_empty(),
+        "this image reads nothing outside the loader's namespace"
+    );
+    assert!(contract.external.ignore.iter().any(|p| p == "KUBERNETES_*"));
+    assert!(contract.external.ignore.iter().any(|p| p == "HOSTNAME"));
+}


### PR DESCRIPTION
Wires the `dev.terrace.config.*` image labels into the container build: generated from the Rust
config types, pasted into the Dockerfile, and checked against the image that was actually built,
before the contract is attached to the digest and signed.

This is the deployment-side half of what #481 made documentation out of. Rebased onto it, so the
`config-schema` feature, the `Describe` derives, `config::schema()` and the public `terrace()` are
all reused rather than reinvented — the delta to `src/config.rs` is ten lines.

## What the image now carries

| Carrier | Where |
|---|---|
| `dev.terrace.config.contract.version` / `.contract.path` / `.prefix` | the image config blob, on every platform in the index |
| `/config/contract.json` | the image filesystem, at the path the `contract.path` label names |
| an `application/vnd.terrace.config-schema.v1+json` referrer, cosign-signed | attached to the pushed digest |

All three are rendered from one `Contract`, built once per build in one stage.

## Rust side

- `terrace-config` v0.5.0 → v0.6.0, which is where the contract types live. Additive: the
  `loader`, `explain` and `testing` halves are unchanged.
- `src/config/contract.rs` builds the document from `config::schema()`, so it describes the
  `Config` this binary deserialises rather than a second account of it. It is in the library
  rather than in the example because an example cannot be tested.
- `examples/config-contract.rs` is a command line over it — `--format contract|labels|dockerfile`.
  The documentation renderings stay with `readme-variables`; neither duplicates the other.
- `app.version` is a `--version` flag rather than `CARGO_PKG_VERSION`. Derived, it would go stale
  the moment release-please bumped `Cargo.toml` and would fail the drift gate on every release
  pull request, over a field with nothing to do with the configuration surface. The container
  build passes the tag; the committed copy omits it.

## Build

- `contract-builder` emits `contract.json` and `contract.labels` together. It is `FROM chef`, not
  `FROM builder`: the generator needs the source and the toolchain but not the release binary, so
  it does not queue behind a fat-LTO musl build. Its cargo caches are its own — the two stages run
  concurrently and a shared `sharing=shared` mount had them racing to clone the git dependency.
- `contract-export` is a `FROM scratch` stage holding just those two files, so
  `--output type=local` puts them on the host without unpacking the toolchain with them.
- The `LABEL` block in `runtime` is `--format dockerfile` output, pasted.

## Gates

Blocking, on every pull request:

- `.github/scripts/check-contract-drift.sh` — regenerates `docs/config.contract.json` and the
  Dockerfile's `LABEL` block and diffs both. Run it locally and it *is* the fix.
- the built image's `.Config.Labels` against `contract.labels`, per architecture.
- the in-image `/config/contract.json` against the exported copy. The path is read from the label,
  so a `COPY` that lands the document somewhere the label does not name fails here.

Blocking, on release, before anything is signed or attached: the same two comparisons against
**every** platform the pushed index lists — enumerated from the index rather than from the build
matrix — read with `crane config --platform` / `crane export --platform`.

`.github/scripts/verify-contract-labels.sh` is the shared comparison. It mirrors
`Contract::verify_labels`: presence and equality of the three, extra labels ignored, every
violation reported before exit. It refuses a labels document that is not a JSON object (reading
`.Config.Labels` where `.config.Labels` was meant yields `null`, which a careless comparison
passes), an empty expectation file, and a missing `jq`.

`tests/config_contract.rs` covers the library half without Docker: the labels agreeing with the
document's own `schema.dialect.prefix`, `verify_labels` accepting what the same contract emitted,
the Dockerfile carrying the generated block and copying the document to the path the label names,
every key being reachable from both a variable and a mounted `Secret`, the webhook being
secret/required/default-less, the published defaults being what `Default` produces, and the
external surface accounting for what a pod injects.

## Falsification

Both tests from the brief were run against real images built from this Dockerfile:

- deleting `dev.terrace.config.contract.path` from the `LABEL` block →
  `error: linux/amd64: the image carries no 'dev.terrace.config.contract.path', so nothing can discover this contract from its config blob.`
- renaming the loader's prefix to `NETCUP_BOT_` in Rust, Dockerfile untouched →
  `error: linux/amd64: the image's 'dev.terrace.config.prefix' is 'NETCUP_OFFER_BOT_', and this contract's is 'NETCUP_BOT_'.`

The drift gate was falsified the same way and caught a real defect while being written: `grep -z`
splits its *pattern* on newlines, so a three-line block matched a Dockerfile carrying only the
first line. It is a bash substring test now.

## Not done, and why

- **The chart-side acceptance test could not be run.** `TimSchoenle/helm-charts@master` does not
  yet contain the consuming half — no `just/contracts.just`, no `.github/scripts/refresh-contracts.py`,
  no `.github/scripts/check-config.py`, no `charts/*/config-contract.yaml`, and no reference to
  `terrace` anywhere. There is nothing to run the new digest against. That repository is
  untouched, as required.
- **The signer identity cannot be confirmed, and probably will not match the shape the design
  quotes.** The contract is signed from `.github/workflows/release-please.yaml` on a push to
  `master`, so the workflow identity is
  `https://github.com/TimSchoenle/netcup-offer-bot/.github/workflows/release-please.yaml@refs/heads/master`
  — not `.../release.yml@refs/tags/...`. This is the identity that already signs the images, so
  whatever regexp the chart repo eventually pins has to admit it either way.
- **`oras` is pinned to 1.3.0** — the number the design names. The chart repo pins nothing, so it
  could not be confirmed against a `justfile`. `cosign` is left as-is: already version-pinned
  transitively through the SHA-pinned `sigstore/cosign-installer`.
- **Docker Hub does not implement the OCI referrers API**, so `oras attach` will use the
  `sha256-<digest>.<suffix>` fallback tag. `oras discover` resolves it transparently, which is why
  the signing step discovers the referrer rather than assuming its digest — but a consumer using a
  client without that fallback will not find it.
