### PR TITLE
fix(ci): make the contract attach and its discover actually work

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -355,37 +355,66 @@ jobs:
       # pins, and a tag can be moved. Attached verbatim — the bytes the generator wrote, with
       # nothing added afterwards. There is no digest field to fill in; the attachment to a
       # digest *is* the tie between image and document.
+      #
+      # Two spellings this step is picky about, both of which fail it outright:
+      #
+      #  - the registry is named. `oras` applies no implicit `docker.io` default the way buildx,
+      #    crane and cosign do — it reads the first segment of a bare `user/repo` as a registry
+      #    hostname and tries to resolve it in DNS.
+      #  - the contract is passed as a relative path from its own directory. `oras` rejects an
+      #    absolute one outright, and `--disable-path-validation` would only trade that for a
+      #    runner path published as the attachment's title annotation.
       - name: Attach the config contract to the digest
         env:
+          IMAGE: docker.io/${{ env.DOCKER_REPO }}
           DIGEST: ${{ steps.manifest.outputs.digest }}
         run: |
           set -euo pipefail
+          cd /tmp
           oras attach \
             --artifact-type application/vnd.terrace.config-schema.v1+json \
-            "${DOCKER_REPO}@${DIGEST}" \
-            /tmp/contract.json:application/json
+            "${IMAGE}@${DIGEST}" \
+            contract.json:application/json
 
-      # Discovered rather than assumed: `oras attach` does not report the referrer's own digest,
-      # and on a registry without the referrers API — Docker Hub — the attachment lands under
-      # the fallback tag scheme, which only a discover call resolves.
+      # Discovered rather than assumed: `oras attach` does not report the referrer's own digest.
+      #
+      # Polled rather than read once. Docker Hub serves the referrers API, so the attachment does
+      # not land under the fallback tag scheme — but its index is eventually consistent, and
+      # `/v2/.../referrers/<digest>` keeps answering with an empty index for seconds after the
+      # attach returns. A single read here fails the release over a contract that is attached.
       - name: Sign the config contract with GitHub OIDC Token
         env:
+          IMAGE: docker.io/${{ env.DOCKER_REPO }}
           DIGEST: ${{ steps.manifest.outputs.digest }}
         run: |
           set -euo pipefail
 
-          referrer="$(oras discover --format json \
-            --artifact-type application/vnd.terrace.config-schema.v1+json \
-            "${DOCKER_REPO}@${DIGEST}" | jq -r '.manifests[0].digest // empty')"
+          referrer=""
+          for attempt in 1 2 3 4 5 6; do
+            if [ "${attempt}" -gt 1 ]; then
+              sleep $(( (attempt - 1) * 5 ))
+            fi
+
+            # `.referrers` is the shape oras 1.3 emits; `.manifests` is accepted so a version bump
+            # that renames the field fails visibly here rather than signing nothing.
+            referrer="$(oras discover --format json \
+              --artifact-type application/vnd.terrace.config-schema.v1+json \
+              "${IMAGE}@${DIGEST}" \
+              | jq -r 'first((.referrers // .manifests // [])[].digest) // empty')"
+
+            if [ -n "${referrer}" ]; then
+              break
+            fi
+          done
 
           if [ -z "${referrer}" ]; then
-            echo "error: no config-schema referrer on ${DIGEST}, immediately after attaching" >&2
-            echo "       one. The registry did not keep it, and an unsigned contract is one no" >&2
-            echo "       chart will vendor." >&2
+            echo "error: no config-schema referrer on ${DIGEST}, 75s after attaching one. The" >&2
+            echo "       registry did not keep it, and an unsigned contract is one no chart" >&2
+            echo "       will vendor." >&2
             exit 1
           fi
 
-          cosign sign --yes "${DOCKER_REPO}@${referrer}"
+          cosign sign --yes "${IMAGE}@${referrer}"
 
   sentry-release:
     environment:


### PR DESCRIPTION
## Problem

[Release run 32230268720](https://github.com/TimSchoenle/netcup-offer-bot/actions/runs/32230268720/job/96001665189) failed at **Attach the config contract to the digest**:

```
Error: absolute file path detected. If it's intentional, use --disable-path-validation flag to skip this check: /tmp/contract.json
```

That is the first of three defects on this path. Each one hid the next, so fixing only the reported error would have produced two more failed releases.

## What was wrong

**1. Absolute contract path.** `oras attach` rejects an absolute file path, because the path becomes the attachment's `org.opencontainers.image.title` annotation. The step now runs from `/tmp` and passes `contract.json`. `--disable-path-validation` would also have worked, at the cost of publishing `/tmp/contract.json` as the title.

**2. Unqualified image reference.** `DOCKER_REPO` is the bare Docker Hub form `user/repo`. Unlike buildx, crane and cosign, `oras` applies no implicit `docker.io` default — it parses the first path segment as a registry hostname and resolves it in DNS. This is the error the sibling repositories hit once they got past their own first failure:

```
failed to resolve sha256:...: dial tcp: lookup *** on 127.0.0.53:53: server misbehaving
```

Both `oras` steps now name `docker.io` explicitly. `docker.io` is the form `oras-go` maps to the `registry-1.docker.io` endpoint (`registry.Reference.Host()`) and to the `https://index.docker.io/v1/` credential entry `docker/login-action` writes (`auth.ServerAddressFromRegistry`), so the existing login still authenticates.

**3. Wrong jq key.** The discover read `.manifests[0].digest`. `oras discover --format json` serializes its node as `Referrers []*Node \`json:"referrers"\`` — `.manifests` is always `null`, so `null[0].digest // empty` yields empty and the step could only ever have reported that nothing was attached. Both keys are now accepted, `.referrers` first.

## Also fixed: the referrers index is eventually consistent

Docker Hub's referrers index does not list an attachment immediately. `oras attach` returns as soon as the referrer manifest is stored, but `/v2/<repo>/referrers/<digest>` keeps answering with an empty index for seconds afterwards.

This is confirmed, not inferred. [`mp-stats-legacy-viewer` v0.17.0](https://github.com/TimSchoenle/mp-stats-legacy-viewer/actions/runs/32225323396/job/95984282436) reached this point first, because its reference was already registry-qualified. Its attach printed the referrer digest `sha256:2cad9caa…`; the discover 200ms later returned an empty list and failed the release. Querying the same endpoint today returns that exact referrer, with `artifactType: application/vnd.terrace.config-schema.v1+json`.

The discover is therefore retried on a 5/10/15/20/25s schedule before the step gives up. The comment claiming Docker Hub has no referrers API and that the attachment lands under the fallback tag scheme goes with it: the registry answers `/referrers/` with a `200` and an OCI index, so `oras` does not write the fallback tag, and none exists for that digest.

## Verification

- Workflow YAML parses; every `run:` block in the file passes `bash -n`.
- Root cause 2 confirmed against `oras-go` upstream for both reference parsing and credential lookup; root cause 3 against `oras` v1.3.3's `discover.go` output model.
- The referrers lag was confirmed against Docker Hub's live registry API, as described above.
- End-to-end confirmation needs a release run, since these steps only execute on `release_created`.

## Note

v2.1.0 shipped signed but with no contract attached. Re-attaching to that digest needs a manual `oras attach`, or it can wait for the next release.
