### PR TITLE
docs: render the README and a configuration page from one payload

### DIFF
--- a/.github/templates/CONFIGURATION.md.hbs
+++ b/.github/templates/CONFIGURATION.md.hbs
@@ -1,0 +1,96 @@
+<!--
+Generated from .github/templates/CONFIGURATION.md.hbs. Edit that file, not this one.
+
+Rendered by the same job that renders README.md, from the same payload, so the tables here and
+the one there come out of one run of:
+
+    cargo run --quiet --features config-schema --example readme-variables
+
+Nothing in this comment may contain a mustache that is not a real reference.
+-->
+
+# Configuration
+
+Every configuration key this service reads, in every spelling that can supply it.
+
+The layering, the two required keys and the key table are in
+[the README](../README.md#configuration). What follows is the detail that does not fit on a page
+someone reads to decide whether to run this at all.
+
+## The variables read before the layers exist
+
+These decide what the layers are, so no layer can supply them.
+
+{{{ config_loader }}}
+
+## The two further spellings of every key
+
+Both are mechanical, which is why the key table names only the environment variable:
+
+- Appending `{{ indirection_suffix }}` to the environment variable makes it name a file holding the value.
+- The TOML path with `.` replaced by `{{ nesting_separator }}` is that key's file name inside
+  `${{ prefix }}SECRETS_DIR`.
+
+So `discord.webhook_url` is supplied by `{{ prefix }}DISCORD{{ nesting_separator }}WEBHOOK_URL`, by
+`{{ prefix }}DISCORD{{ nesting_separator }}WEBHOOK_URL{{ indirection_suffix }}=/path`, or by a file named `discord{{ nesting_separator }}webhook_url` in
+the secrets directory. Supplying it by two of the three fails the boot.
+
+## `config.toml`
+
+Every key, commented out wherever leaving it out changes nothing, so this file and an empty one
+mean the same thing to the loader. What is left uncommented is what has to be supplied, and each
+of those carries a placeholder rather than a value: a copy left unedited fails at the key nobody
+filled in rather than running on it.
+
+```toml
+{{{ config_toml }}}
+```
+
+## Secrets from files
+
+A Kubernetes `Secret` mounted as a volume, one file per key. The provider follows the `..data`
+indirection a projected volume uses, so the mount works as written:
+
+```bash
+docker run --rm \
+  -e {{ prefix }}SECRETS_DIR="/run/secrets" \
+  -e {{ prefix }}FEED{{ nesting_separator }}CHECK_INTERVAL_SECS=900 \
+  -v ./webhook:/run/secrets/discord{{ nesting_separator }}webhook_url:ro \
+  -v netcup-offer-bot-data:/app/data \
+  {{ image }}:{{ release.tag }}
+```
+
+For a single secret, Docker's own convention reaches the same place:
+
+```bash
+-e {{ prefix }}DISCORD{{ nesting_separator }}WEBHOOK_URL{{ indirection_suffix }}="/run/secrets/webhook"
+```
+
+## The config contract
+
+Every release publishes the key table as a machine-readable document, so a chart deploying an
+image can be checked against the keys that image reads rather than against a copy of this page.
+The committed copy is [config.contract.json](config.contract.json).
+
+Each image carries the same document three ways:
+
+| Carrier | What it answers |
+| --- | --- |
+| `LABEL dev.terrace.config.*` in the image config blob | Does this image declare a contract, where is its offline copy, and which environment variables are its business. One registry request, no layer pull |
+| `/config/contract.json` in the image | The offline copy, for a `docker save` tarball or an air-gapped mirror |
+| An OCI referrer of type `application/vnd.terrace.config-schema.v1+json` on the pushed digest, cosign-signed | The canonical fetch, tied to the exact build a chart pins |
+
+One program renders all three:
+
+```bash
+cargo run --features config-schema --example config-contract -- --format contract
+cargo run --features config-schema --example config-contract -- --format labels
+cargo run --features config-schema --example config-contract -- --format dockerfile
+```
+
+After changing a configuration key, `just regenerate` rewrites the committed document and the
+region between the `terrace-config:labels` markers in the `Dockerfile`. It writes and never
+checks. The checking is `TimSchoenle/actions/actions/rust/config-contract`, which diffs both
+against the configuration types on every pull request and then checks the built image against
+the labels the same generator emitted, one platform at a time, before anything is attached to
+the digest or signed.

--- a/.github/templates/README.md.hbs
+++ b/.github/templates/README.md.hbs
@@ -1,190 +1,238 @@
 <!--
-Generated from .github/templates/README.md.hbs — edit that file, not this one. CI renders it on
-every pull request and commits the result back to the branch; a push to master whose README.md
-does not match its template fails the `readme` check in .github/workflows/docs.yaml.
+Generated from .github/templates/README.md.hbs. Edit that file, not this one.
 
-Variables come from `cargo run --features config-schema --example readme-variables`:
+CI renders it on every pull request and commits the result back to the branch. A push to master
+whose README.md does not match its template fails the `README` job in
+.github/workflows/docs.yaml.
 
-    version              the [package] version, e.g. 2.0.1
-    repository           the GitHub repository, as owner/name
-    branch               the branch permanent links point at
-    image                the Docker Hub repository the image is published to
-    prefix               the prefix every configuration variable carries
-    nesting_separator    what separates nesting levels in an environment key
-    indirection_suffix   what marks a variable holding a path rather than a value
-    config_loader        the table of variables the loader reads
-    config_keys          the table of configuration keys
-    config_toml          a config.toml carrying every key
+The configuration half of the payload comes from one command:
 
-The last three are derived from the `Config` type itself, by way of terrace-config's `schema`
-feature. Adding a key, changing a default or rewriting a field's doc comment updates this page in
-the same commit that changes the code — which is the point: a reference table maintained beside
-the type is a table that is wrong by the second release.
+    cargo run --quiet --features config-schema --example readme-variables
+
+The rest is derived by TimSchoenle/actions/actions/common/readme-variables, which reads
+Cargo.toml and walks docs/. Every string this page quotes that also lives in a manifest arrives
+that way, so no release, licence or edition is typed here.
+
+Nothing in this comment may contain a mustache that is not a real reference.
 -->
-<br/>
-<p align="center">
-  <h3 align="center">Netcup Offer Bot</h3>
 
-  <p align="center">
-    <a href="https://github.com/{{ repository }}/issues">Report Bug</a>
-    .
-    <a href="https://github.com/{{ repository }}/issues">Request Feature</a>
-  </p>
-</p>
+# {{ repo.name }}
 
-<div align="center">
+{{ repo.description }}
 
-![Docker Image Version (latest semver)](https://img.shields.io/docker/v/{{ image }})
-![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/{{ repository }}/build.yaml)
-![Issues](https://img.shields.io/github/issues/{{ repository }})
-[![codecov](https://codecov.io/gh/{{ repository }}/branch/{{ branch }}/graph/badge.svg?token=JEK95V1906)](https://codecov.io/gh/{{ repository }})
-![License](https://img.shields.io/github/license/{{ repository }})
+[![Release](https://img.shields.io/github/v/release/{{ repo.slug }}?sort=semver)](https://github.com/{{ repo.slug }}/releases)
+[![Build](https://img.shields.io/github/actions/workflow/status/{{ repo.slug }}/build.yaml?branch={{ repo.branch }})](https://github.com/{{ repo.slug }}/actions/workflows/build.yaml)
+[![Coverage](https://codecov.io/gh/{{ repo.slug }}/branch/{{ repo.branch }}/graph/badge.svg?token=JEK95V1906)](https://codecov.io/gh/{{ repo.slug }})
+[![License](https://img.shields.io/github/license/{{ repo.slug }})](LICENSE)
 
-</div>
+## What this is
 
-## About The Project
+One process. It polls the netcup deals RSS feed at <https://www.netcup.com/rss/deals/de> and
+posts each item it has not seen before to a Discord webhook, as an embed carrying the title,
+description, link, publication date and categories.
 
-RSS feed listener to discord webhook for https://www.netcup.com/de/deals
+Seen is decided by publication date. After every round the newest `pubDate` is written to
+`./data/feed_state.json`, and an item dated at or before it is skipped. A process that starts
+without that file holds no watermark, so it posts everything the feed currently lists.
 
-### Installation - Helm chart
+The configuration table below is generated from the Rust types that load the configuration. So
+are [docs/config.contract.json](docs/config.contract.json) and the `dev.terrace.config.*` labels
+every image carries, which is what lets a chart be checked against the keys the image reads
+rather than against a copy of this page.
 
-- [Helm chart](https://github.com/TimSchoenle/helm-charts/tree/main/charts/netcup-offer-bot)
+## Quick start
 
-### Installation - Docker
+```bash
+docker run --rm \
+  -e {{ prefix }}DISCORD{{ nesting_separator }}WEBHOOK_URL="https://discord.com/api/webhooks/..." \
+  -e {{ prefix }}FEED{{ nesting_separator }}CHECK_INTERVAL_SECS=900 \
+  -v netcup-offer-bot-data:/app/data \
+  {{ image }}:{{ release.tag }}
+```
 
-- [Docker Image](https://hub.docker.com/repository/docker/{{ image }})
+Those two variables are the only required keys. The volume holds the watermark; drop it and
+every restart reposts whatever the feed still lists.
 
-The image is published as a multi-platform manifest for `linux/amd64` and `linux/arm64`. Docker pulls
-the matching architecture automatically, so the commands below are identical on both.
+## Table of contents
 
-#### Quick start
+- [Features](#features)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Configuration](#configuration)
+- [Operations](#operations)
+- [Compatibility](#compatibility)
+- [Documentation](#documentation)
+- [Contributing](#contributing)
+- [Security](#security)
+- [License](#license)
 
-The examples pin `{{ version }}`, the release this page was generated from; `latest` tracks the newest.
+## Features
 
-```shell
-  docker run \
-    --name netcup-offer-bot \
-    -e {{ prefix }}DISCORD{{ nesting_separator }}WEBHOOK_URL="https://discord.com/api/webhooks/..." \
-    -e {{ prefix }}FEED{{ nesting_separator }}CHECK_INTERVAL_SECS="180" \
-    -v netcup-offer-bot-data:/app/data \
-    -d \
-    {{ image }}:{{ version }}
-  ```
+- **The webhook can arrive as a file.** `{{ prefix }}<KEY>{{ indirection_suffix }}` names a path, and a secrets
+  directory supplies one key per file, so a mounted Kubernetes `Secret` reaches the process
+  without the URL turning up in `docker inspect` or in a child process environment.
+- A key supplied by two of the environment, the secrets directory and `{{ indirection_suffix }}` indirection fails
+  the boot naming both sources. Resolving it by precedence would let a stale variable go on
+  shadowing a webhook that has since been rotated.
+- Delivery retries five times. A `429` waits out the `retry-after` header plus a second; a `5xx`
+  or a connection failure backs off two seconds, then four, then eight. The fifth failure gives
+  up on that item and counts it.
+- A feed payload that does not begin with an `rss` tag is logged as a warning instead of counted
+  as a fetch error, because the upstream answers with an HTML page often enough that alerting on
+  it would be alerting on netcup's bad minute.
+- Four Prometheus metrics, on an exporter that binds `127.0.0.1:9184` by default.
+- Errors reach Sentry when a DSN is configured. The image build uploads debug symbols before it
+  strips the binary, so a musl release build still symbolicates.
+
+## Installation
+
+### Docker
+
+```bash
+docker pull {{ image }}:{{ release.tag }}
+```
+
+Published as a multi-platform manifest for `linux/amd64` and `linux/arm64`. Every release is
+pushed by digest, signed with cosign, and carries its configuration contract as an OCI referrer
+on that digest. Pin by digest in production. The Helm chart does.
+
+### Helm
+
+```bash
+helm repo add timschoenle https://timschoenle.github.io/helm-charts
+helm install netcup-offer-bot timschoenle/netcup-offer-bot
+```
+
+The chart pins the image by digest, and this repository's release workflow bumps it. Its values
+are at
+[TimSchoenle/helm-charts](https://github.com/TimSchoenle/helm-charts/tree/main/charts/netcup-offer-bot).
+
+### From source
+
+```bash
+git clone https://github.com/{{ repo.slug }}.git
+cd {{ repo.name }}
+cargo build --release
+```
+
+## Usage
+
+The binary takes no arguments. Everything it reads is configuration, and the two required keys
+have to come from somewhere before it starts:
+
+```bash
+{{ prefix }}DISCORD{{ nesting_separator }}WEBHOOK_URL{{ indirection_suffix }}=./webhook \
+{{ prefix }}FEED{{ nesting_separator }}CHECK_INTERVAL_SECS=900 \
+  cargo run --release
+```
+
+It writes `./data/feed_state.json` relative to the working directory and creates the directory
+when it is missing.
+
+Run the checks CI runs:
+
+```bash
+just verify            # fmt, clippy, test
+```
+
+After changing a configuration key, rewrite what is generated from it:
+
+```bash
+just regenerate        # docs/config.contract.json and the Dockerfile LABEL region
+```
 
 ## Configuration
 
-Configuration is layered by [terrace-config](https://github.com/TimSchoenle/terrace-config), so the
-Discord webhook can arrive as a mounted file rather than as an environment variable that shows up
-in `docker inspect` and in the environment of every child process.
-
+Configuration is layered by [terrace-config](https://github.com/TimSchoenle/terrace-config).
 Lowest precedence first:
 
 1. The defaults compiled into the config structs.
-2. TOML at `${{ prefix }}CONFIG`, defaulting to `./config.toml` — a file, or every `*.toml`
-   directly inside it when it names a directory, merged in file-name order. A missing file is not
-   an error.
+2. TOML at `${{ prefix }}CONFIG`, defaulting to `./config.toml`. A file, or every `*.toml`
+   directly inside it when it names a directory, merged in file-name order. A missing file is
+   not an error.
 3. `{{ prefix }}`-prefixed environment variables.
 4. Every key-named file in `${{ prefix }}SECRETS_DIR`.
-5. `{{ prefix }}<KEY>{{ indirection_suffix }}=/path`, which reads `<KEY>` from that path.
+5. `{{ prefix }}<KEY>{{ indirection_suffix }}=/path`, which reads the value from that path.
 
-**Layers 3, 4 and 5 are mutually exclusive per key.** A key supplied by two of them fails the boot
-naming the key and both sources, rather than being resolved by precedence: a stale environment
-variable shadowing a webhook that has since been rotated would otherwise keep the bot posting to
-the old one, and the discrepancy would surface long after the deploy that caused it.
+The last three are mutually exclusive per key. Two of them supplying one key fails the boot,
+naming the key and both sources.
 
-**Nesting is `{{ nesting_separator }}`** — a single underscore is part of a field name. Case is folded,
-so `discord.webhook_url` is `{{ prefix }}DISCORD{{ nesting_separator }}WEBHOOK_URL` as a variable and
+Nesting is `{{ nesting_separator }}`, because a single underscore is part of a field name. Case is folded, so
+`discord.webhook_url` is `{{ prefix }}DISCORD{{ nesting_separator }}WEBHOOK_URL` as a variable and
 `discord{{ nesting_separator }}webhook_url` as a file name.
-
-Run with `{{ prefix }}TELEMETRY{{ nesting_separator }}LOG_LEVEL=DEBUG` and the boot log names the layer
-every key was read from, which is what answers "the `Secret` is mounted and the bot is still posting
-to the old webhook".
-
-#### The variables read before the layers exist
-
-These decide what the layers *are*, so no layer can supply them.
-
-{{{ config_loader }}}
-
-#### Keys
 
 {{{ config_keys }}}
 
-Every key has two further spellings, both mechanical and both left out of the table to keep it inside
-a page: appending `{{ indirection_suffix }}` to the environment variable names a *file* holding the value,
-and the TOML path with `.` replaced by `{{ nesting_separator }}` is that key's file name inside the secrets
-directory.
+Run with `{{ prefix }}TELEMETRY{{ nesting_separator }}LOG_LEVEL=DEBUG` and the boot log names the layer every
+key was read from. That is what answers "the `Secret` is mounted and the bot is still posting to
+the old webhook".
 
-#### `config.toml`
+[docs/CONFIGURATION.md](docs/CONFIGURATION.md) has the rest: the two variables the loader reads
+before any layer exists, both further spellings of every key, a `config.toml` carrying all of
+them, the secrets-directory recipes, and the contract each image publishes.
 
-Every key, commented out wherever leaving it out changes nothing, so this file and an empty one mean
-the same thing to the loader. What is left uncommented is exactly what has to be supplied — and each
-of those carries a placeholder rather than a value, so a copy left unedited fails at the key that was
-never filled in rather than running on it.
+## Operations
 
-```toml
-{{{ config_toml }}}
-```
+### Metrics
 
-#### Secrets from files
+The Prometheus exporter serves `/metrics` on the address `metrics.ip` and `metrics.port` name,
+`127.0.0.1:9184` unless configured otherwise. Bind `0.0.0.0` to reach it from outside the
+container.
 
-A Kubernetes `Secret` mounted as a volume, one file per key — the provider follows the `..data`
-indirection a projected volume uses, so the mount works as written:
+| Metric | Type | Labels | Reports |
+| --- | --- | --- | --- |
+| `feed_counter` | counter | `feed` | Items a round found to be new, counted before they are sent |
+| `feed_fetch_duration_seconds` | histogram | `feed` | Seconds one fetch of the feed took |
+| `feed_fetch_errors_total` | counter | `feed` | Fetches that failed, malformed payloads excluded |
+| `webhook_errors_total` | counter | `feed` | Items still undelivered after the fifth attempt |
 
-```shell
-  docker run \
-    --name netcup-offer-bot \
-    -e {{ prefix }}SECRETS_DIR="/run/secrets" \
-    -e {{ prefix }}FEED{{ nesting_separator }}CHECK_INTERVAL_SECS="180" \
-    -v ./webhook:/run/secrets/discord{{ nesting_separator }}webhook_url:ro \
-    -v netcup-offer-bot-data:/app/data \
-    -d \
-    {{ image }}:{{ version }}
-  ```
+### State
 
-Or Docker's `{{ indirection_suffix }}` convention, for a single secret:
+`./data/feed_state.json` holds one UTC timestamp per feed and is rewritten only by a round that
+moved one. The image's working directory is `/app`, so the file a deployment has to keep is
+`/app/data/feed_state.json`.
 
-```shell
-  -e {{ prefix }}DISCORD{{ nesting_separator }}WEBHOOK_URL{{ indirection_suffix }}="/run/secrets/webhook"
-  ```
+### Runtime posture
 
-#### The config contract
+The runtime stage is `FROM scratch`. It carries the stripped binary, the CA bundle, the zone
+database, `/etc/passwd`, `/etc/group` and the offline copy of the configuration contract at
+`/config/contract.json`. The process runs as `1001:1001` and writes to `/app/data` and stdout,
+nothing else.
 
-Every release publishes the table above as a machine-readable document, so a chart deploying this
-image can be checked against what the image actually reads rather than against a copy of this page
-that may have drifted. The committed copy is [`docs/config.contract.json`](docs/config.contract.json).
+## Compatibility
 
-Each image carries the same document three ways:
+| | Supported |
+| --- | --- |
+| Rust | edition {{ toolchain.edition }} |
+| Platforms | `linux/amd64`, `linux/arm64` |
+| Helm chart | [`timschoenle/netcup-offer-bot`](https://github.com/TimSchoenle/helm-charts/tree/main/charts/netcup-offer-bot) |
 
-| Carrier | What it answers |
-|---|---|
-| `LABEL dev.terrace.config.*` in the image config blob | Does this image declare a contract, where is its offline copy, and which environment variables are its business — answerable in one registry request, with no layer pull |
-| `/config/contract.json` in the image | The offline copy, for a `docker save` tarball or an air-gapped mirror |
-| An OCI referrer of type `application/vnd.terrace.config-schema.v1+json` on the pushed digest, cosign-signed | The canonical fetch, tied to the exact build a chart pins |
+## Documentation
 
-All three are rendered from the same document by one program:
+| Document | Purpose |
+| --- | --- |
+{{#each docs}}| [{{ path }}]({{ path }}) | {{ default (mdCell summary) "—" }} |
+{{/each}}
 
-```shell
-cargo run --features config-schema --example config-contract -- --format contract
-cargo run --features config-schema --example config-contract -- --format labels
-cargo run --features config-schema --example config-contract -- --format dockerfile
-```
+## Contributing
 
-After changing a configuration key, regenerate the committed copy and the Dockerfile's `LABEL`
-region:
+Issues and pull requests are welcome. Commit messages follow Conventional Commits, which is what
+release-please reads to decide the next version, and `just verify` runs the checks a pull request
+is going to run anyway.
 
-```shell
-just regenerate
-```
+Four things here are generated, and each names its source in its first lines: `README.md`,
+`docs/CONFIGURATION.md`, `docs/config.contract.json` and the `LABEL` region of the `Dockerfile`.
+`just regenerate` rewrites the last two. CI renders the first two, commits the result back to the
+branch, and fails a push to {{ repo.branch }} that does not match.
 
-It rewrites `docs/config.contract.json` and the region between the `terrace-config:labels` markers
-in the `Dockerfile`, so a local run is the fix rather than a report. It writes and never checks —
-the checking is `TimSchoenle/actions/actions/rust/config-contract`, which diffs both against the
-configuration types on every pull request and then checks the built **image** against the labels
-the same generator emitted. The release workflow checks every platform in the index separately,
-before anything is attached to the digest or signed.
+## Security
+
+Do not open a public issue for a vulnerability. [SECURITY.md](SECURITY.md) has the reporting
+route and the supported versions.
+
+The Discord webhook is the one credential this process holds, and anyone holding it can post to
+the channel. Supply it as a file rather than as an environment variable.
 
 ## License
 
-Distributed under the MIT License. See [LICENSE](https://github.com/{{ repository }}/blob/{{ branch }}/LICENSE)
-for more information.
+`{{ repo.license }}`. [LICENSE](LICENSE) has the terms.

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -87,7 +87,8 @@ jobs:
         id: config
         run: |
           set -euo pipefail
-          echo "json=$(cargo run --quiet --features config-schema --example readme-variables)" >> "$GITHUB_OUTPUT"
+          json="$(cargo run --quiet --features config-schema --example readme-variables)"
+          echo "json=${json}" >> "$GITHUB_OUTPUT"
 
       # `branch` names the default branch rather than taking its own default of `github.ref_name`.
       # On a pull_request event that is `<number>/merge`, which would render badge and permalink
@@ -165,7 +166,8 @@ jobs:
         id: config
         run: |
           set -euo pipefail
-          echo "json=$(cargo run --quiet --features config-schema --example readme-variables)" >> "$GITHUB_OUTPUT"
+          json="$(cargo run --quiet --features config-schema --example readme-variables)"
+          echo "json=${json}" >> "$GITHUB_OUTPUT"
 
       # `branch` names the default branch rather than taking its own default of `github.ref_name`.
       # On a pull_request event that is `<number>/merge`, which would render badge and permalink

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,10 +1,10 @@
 name: Docs
 
-# `README.md` is generated from `.github/templates/README.md.hbs`. This workflow is what makes
-# that claim true in both directions.
+# `README.md` and `docs/CONFIGURATION.md` are generated from the templates in
+# `.github/templates/`. This workflow is what makes that claim true in both directions.
 #
-# On a pull request it renders the template and commits the result to the branch, so nothing the
-# README quotes is ever edited by hand: not the crate version its `docker run` examples pin, and
+# On a pull request it renders both templates and commits the result to the branch, so nothing
+# either page quotes is ever edited by hand: not the release its `docker run` examples pin, and
 # not the configuration tables, which are derived from the `Config` type by the
 # `readme-variables` example. The case that matters most is the release-please pull request —
 # that commit is the one which changes `version` in `Cargo.toml`, so it is also the one where the
@@ -12,9 +12,9 @@ name: Docs
 # released README already pins the version the merge is about to publish.
 #
 # Everywhere it cannot commit — a push to `master`, a pull request from a fork — it renders in
-# `check` mode instead, writing nothing and failing if the committed `README.md` is stale.
-# Without it, editing `README.md` directly would appear to work right up until the next pull
-# request silently reverted it.
+# `check` mode instead, writing nothing and failing if either committed file is stale. Without
+# it, editing a generated page directly would appear to work right up until the next pull request
+# silently reverted it.
 
 on:
   push:
@@ -78,19 +78,48 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
 
-      - name: Collect README variables
-        id: variables
-        run: echo "json=$(cargo run --quiet --features config-schema --example readme-variables)" >> "$GITHUB_OUTPUT"
+      # Two steps rather than one. The first is the only part of the payload this repository can
+      # answer for itself — the configuration tables and the dialect they are written in, out of
+      # the `Config` type. The second derives the rest from `Cargo.toml` and `docs/`, and
+      # deep-merges the first over it, so the release, the licence and the documentation index
+      # come from the files that already hold them.
+      - name: Generate the configuration payload
+        id: config
+        run: |
+          set -euo pipefail
+          echo "json=$(cargo run --quiet --features config-schema --example readme-variables)" >> "$GITHUB_OUTPUT"
 
-      - name: Render and commit the README
+      # `branch` names the default branch rather than taking its own default of `github.ref_name`.
+      # On a pull_request event that is `<number>/merge`, which would render badge and permalink
+      # URLs the push to master then disagrees with, and the gate below would fail on every merge
+      # for a reason absent from the diff.
+      - name: Collect the README payload
+        id: variables
+        uses: TimSchoenle/actions/actions/common/readme-variables@b5b5c9e047f00ffa00b7772536c8bdb4f158f706 # tag=actions-common-readme-variables-v1.1.0
+        with:
+          branch: ${{ github.event.repository.default_branch }}
+          extra: ${{ steps.config.outputs.json }}
+
+      # Written but not committed here. The commit is the step below, over both files at once:
+      # two commits would each have to name the head the other just moved, and the API call that
+      # makes a verified commit rejects one whose parent has changed.
+      - name: Render the configuration page
+        uses: TimSchoenle/actions/actions/common/render-template@3b7d152374ee63e720e7c16bed8b088b40554911 # tag=actions-common-render-template-v1.1.1
+        with:
+          template: .github/templates/CONFIGURATION.md.hbs
+          output: docs/CONFIGURATION.md
+          variables: ${{ steps.variables.outputs.variables }}
+
+      - name: Render and commit the generated documentation
         id: readme
         uses: TimSchoenle/actions/actions/common/render-template-and-commit@15d83f02081c9dc8a844646199c63792dcccdfa8 # tag=actions-common-render-template-and-commit-v1.1.3
         with:
           template: .github/templates/README.md.hbs
           output: README.md
-          variables: ${{ steps.variables.outputs.json }}
+          variables: ${{ steps.variables.outputs.variables }}
           token: ${{ steps.generate_token.outputs.token }}
-          commit_message: "docs: render README from template"
+          file_pattern: "README.md docs/CONFIGURATION.md"
+          commit_message: "docs: render README and CONFIGURATION from their templates"
 
       - name: Summarise
         env:
@@ -98,9 +127,9 @@ jobs:
           COMMIT_URL: ${{ steps.readme.outputs.commit_url }}
         run: |
           if [ "${COMMITTED}" = "true" ]; then
-            echo "README.md re-rendered: ${COMMIT_URL}" >> "$GITHUB_STEP_SUMMARY"
+            echo "Generated documentation re-rendered: ${COMMIT_URL}" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "README.md already matched its template." >> "$GITHUB_STEP_SUMMARY"
+            echo "README.md and docs/CONFIGURATION.md already matched their templates." >> "$GITHUB_STEP_SUMMARY"
           fi
 
   check:
@@ -127,15 +156,41 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
 
-      - name: Collect README variables
-        id: variables
-        run: echo "json=$(cargo run --quiet --features config-schema --example readme-variables)" >> "$GITHUB_OUTPUT"
+      # Two steps rather than one. The first is the only part of the payload this repository can
+      # answer for itself — the configuration tables and the dialect they are written in, out of
+      # the `Config` type. The second derives the rest from `Cargo.toml` and `docs/`, and
+      # deep-merges the first over it, so the release, the licence and the documentation index
+      # come from the files that already hold them.
+      - name: Generate the configuration payload
+        id: config
+        run: |
+          set -euo pipefail
+          echo "json=$(cargo run --quiet --features config-schema --example readme-variables)" >> "$GITHUB_OUTPUT"
 
-      # Writes nothing; fails with the first differing line when README.md is stale.
+      # `branch` names the default branch rather than taking its own default of `github.ref_name`.
+      # On a pull_request event that is `<number>/merge`, which would render badge and permalink
+      # URLs the push to master then disagrees with, and the gate below would fail on every merge
+      # for a reason absent from the diff.
+      - name: Collect the README payload
+        id: variables
+        uses: TimSchoenle/actions/actions/common/readme-variables@b5b5c9e047f00ffa00b7772536c8bdb4f158f706 # tag=actions-common-readme-variables-v1.1.0
+        with:
+          branch: ${{ github.event.repository.default_branch }}
+          extra: ${{ steps.config.outputs.json }}
+
+      # Both write nothing; each fails with the first differing line when its output is stale.
+      - name: Verify docs/CONFIGURATION.md is current
+        uses: TimSchoenle/actions/actions/common/render-template@3b7d152374ee63e720e7c16bed8b088b40554911 # tag=actions-common-render-template-v1.1.1
+        with:
+          template: .github/templates/CONFIGURATION.md.hbs
+          output: docs/CONFIGURATION.md
+          variables: ${{ steps.variables.outputs.variables }}
+          check: true
+
       - name: Verify README.md is current
         uses: TimSchoenle/actions/actions/common/render-template@3b7d152374ee63e720e7c16bed8b088b40554911 # tag=actions-common-render-template-v1.1.1
         with:
           template: .github/templates/README.md.hbs
           output: README.md
-          variables: ${{ steps.variables.outputs.json }}
+          variables: ${{ steps.variables.outputs.variables }}
           check: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,12 @@
 name = "netcup-offer-bot"
 version = "2.1.1"
 edition = "2024"
+# Read by the README render as well as by cargo. `readme-variables` takes the repository's
+# one-line description and its licence identifier from here and refuses to take either from the
+# GitHub API, so an edit made in the web UI cannot change the rendered page with no commit behind
+# it.
+description = "Watches the netcup deals RSS feed and posts new offers to a Discord webhook."
+license = "GPL-3.0-only"
 
 [lib]
 path = "src/lib.rs"

--- a/README.md
+++ b/README.md
@@ -1,115 +1,165 @@
 <!--
-Generated from .github/templates/README.md.hbs — edit that file, not this one. CI renders it on
-every pull request and commits the result back to the branch; a push to master whose README.md
-does not match its template fails the `readme` check in .github/workflows/docs.yaml.
+Generated from .github/templates/README.md.hbs. Edit that file, not this one.
 
-Variables come from `cargo run --features config-schema --example readme-variables`:
+CI renders it on every pull request and commits the result back to the branch. A push to master
+whose README.md does not match its template fails the `README` job in
+.github/workflows/docs.yaml.
 
-    version              the [package] version, e.g. 2.0.1
-    repository           the GitHub repository, as owner/name
-    branch               the branch permanent links point at
-    image                the Docker Hub repository the image is published to
-    prefix               the prefix every configuration variable carries
-    nesting_separator    what separates nesting levels in an environment key
-    indirection_suffix   what marks a variable holding a path rather than a value
-    config_loader        the table of variables the loader reads
-    config_keys          the table of configuration keys
-    config_toml          a config.toml carrying every key
+The configuration half of the payload comes from one command:
 
-The last three are derived from the `Config` type itself, by way of terrace-config's `schema`
-feature. Adding a key, changing a default or rewriting a field's doc comment updates this page in
-the same commit that changes the code — which is the point: a reference table maintained beside
-the type is a table that is wrong by the second release.
+    cargo run --quiet --features config-schema --example readme-variables
+
+The rest is derived by TimSchoenle/actions/actions/common/readme-variables, which reads
+Cargo.toml and walks docs/. Every string this page quotes that also lives in a manifest arrives
+that way, so no release, licence or edition is typed here.
+
+Nothing in this comment may contain a mustache that is not a real reference.
 -->
-<br/>
-<p align="center">
-  <h3 align="center">Netcup Offer Bot</h3>
 
-  <p align="center">
-    <a href="https://github.com/TimSchoenle/netcup-offer-bot/issues">Report Bug</a>
-    .
-    <a href="https://github.com/TimSchoenle/netcup-offer-bot/issues">Request Feature</a>
-  </p>
-</p>
+# netcup-offer-bot
 
-<div align="center">
+Watches the netcup deals RSS feed and posts new offers to a Discord webhook.
 
-![Docker Image Version (latest semver)](https://img.shields.io/docker/v/timmi6790/netcup-offer-bot)
-![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/TimSchoenle/netcup-offer-bot/build.yaml)
-![Issues](https://img.shields.io/github/issues/TimSchoenle/netcup-offer-bot)
-[![codecov](https://codecov.io/gh/TimSchoenle/netcup-offer-bot/branch/master/graph/badge.svg?token=JEK95V1906)](https://codecov.io/gh/TimSchoenle/netcup-offer-bot)
-![License](https://img.shields.io/github/license/TimSchoenle/netcup-offer-bot)
+[![Release](https://img.shields.io/github/v/release/TimSchoenle/netcup-offer-bot?sort=semver)](https://github.com/TimSchoenle/netcup-offer-bot/releases)
+[![Build](https://img.shields.io/github/actions/workflow/status/TimSchoenle/netcup-offer-bot/build.yaml?branch=master)](https://github.com/TimSchoenle/netcup-offer-bot/actions/workflows/build.yaml)
+[![Coverage](https://codecov.io/gh/TimSchoenle/netcup-offer-bot/branch/master/graph/badge.svg?token=JEK95V1906)](https://codecov.io/gh/TimSchoenle/netcup-offer-bot)
+[![License](https://img.shields.io/github/license/TimSchoenle/netcup-offer-bot)](LICENSE)
 
-</div>
+## What this is
 
-## About The Project
+One process. It polls the netcup deals RSS feed at <https://www.netcup.com/rss/deals/de> and
+posts each item it has not seen before to a Discord webhook, as an embed carrying the title,
+description, link, publication date and categories.
 
-RSS feed listener to discord webhook for https://www.netcup.com/de/deals
+Seen is decided by publication date. After every round the newest `pubDate` is written to
+`./data/feed_state.json`, and an item dated at or before it is skipped. A process that starts
+without that file holds no watermark, so it posts everything the feed currently lists.
 
-### Installation - Helm chart
+The configuration table below is generated from the Rust types that load the configuration. So
+are [docs/config.contract.json](docs/config.contract.json) and the `dev.terrace.config.*` labels
+every image carries, which is what lets a chart be checked against the keys the image reads
+rather than against a copy of this page.
 
-- [Helm chart](https://github.com/TimSchoenle/helm-charts/tree/main/charts/netcup-offer-bot)
+## Quick start
 
-### Installation - Docker
+```bash
+docker run --rm \
+  -e NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL="https://discord.com/api/webhooks/..." \
+  -e NETCUP_OFFER_BOT_FEED__CHECK_INTERVAL_SECS=900 \
+  -v netcup-offer-bot-data:/app/data \
+  timmi6790/netcup-offer-bot:v2.1.1
+```
 
-- [Docker Image](https://hub.docker.com/repository/docker/timmi6790/netcup-offer-bot)
+Those two variables are the only required keys. The volume holds the watermark; drop it and
+every restart reposts whatever the feed still lists.
 
-The image is published as a multi-platform manifest for `linux/amd64` and `linux/arm64`. Docker pulls
-the matching architecture automatically, so the commands below are identical on both.
+## Table of contents
 
-#### Quick start
+- [Features](#features)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Configuration](#configuration)
+- [Operations](#operations)
+- [Compatibility](#compatibility)
+- [Documentation](#documentation)
+- [Contributing](#contributing)
+- [Security](#security)
+- [License](#license)
 
-The examples pin `2.1.1`, the release this page was generated from; `latest` tracks the newest.
+## Features
 
-```shell
-  docker run \
-    --name netcup-offer-bot \
-    -e NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL="https://discord.com/api/webhooks/..." \
-    -e NETCUP_OFFER_BOT_FEED__CHECK_INTERVAL_SECS="180" \
-    -v netcup-offer-bot-data:/app/data \
-    -d \
-    timmi6790/netcup-offer-bot:2.1.1
-  ```
+- **The webhook can arrive as a file.** `NETCUP_OFFER_BOT_<KEY>_FILE` names a path, and a secrets
+  directory supplies one key per file, so a mounted Kubernetes `Secret` reaches the process
+  without the URL turning up in `docker inspect` or in a child process environment.
+- A key supplied by two of the environment, the secrets directory and `_FILE` indirection fails
+  the boot naming both sources. Resolving it by precedence would let a stale variable go on
+  shadowing a webhook that has since been rotated.
+- Delivery retries five times. A `429` waits out the `retry-after` header plus a second; a `5xx`
+  or a connection failure backs off two seconds, then four, then eight. The fifth failure gives
+  up on that item and counts it.
+- A feed payload that does not begin with an `rss` tag is logged as a warning instead of counted
+  as a fetch error, because the upstream answers with an HTML page often enough that alerting on
+  it would be alerting on netcup's bad minute.
+- Four Prometheus metrics, on an exporter that binds `127.0.0.1:9184` by default.
+- Errors reach Sentry when a DSN is configured. The image build uploads debug symbols before it
+  strips the binary, so a musl release build still symbolicates.
+
+## Installation
+
+### Docker
+
+```bash
+docker pull timmi6790/netcup-offer-bot:v2.1.1
+```
+
+Published as a multi-platform manifest for `linux/amd64` and `linux/arm64`. Every release is
+pushed by digest, signed with cosign, and carries its configuration contract as an OCI referrer
+on that digest. Pin by digest in production. The Helm chart does.
+
+### Helm
+
+```bash
+helm repo add timschoenle https://timschoenle.github.io/helm-charts
+helm install netcup-offer-bot timschoenle/netcup-offer-bot
+```
+
+The chart pins the image by digest, and this repository's release workflow bumps it. Its values
+are at
+[TimSchoenle/helm-charts](https://github.com/TimSchoenle/helm-charts/tree/main/charts/netcup-offer-bot).
+
+### From source
+
+```bash
+git clone https://github.com/TimSchoenle/netcup-offer-bot.git
+cd netcup-offer-bot
+cargo build --release
+```
+
+## Usage
+
+The binary takes no arguments. Everything it reads is configuration, and the two required keys
+have to come from somewhere before it starts:
+
+```bash
+NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL_FILE=./webhook \
+NETCUP_OFFER_BOT_FEED__CHECK_INTERVAL_SECS=900 \
+  cargo run --release
+```
+
+It writes `./data/feed_state.json` relative to the working directory and creates the directory
+when it is missing.
+
+Run the checks CI runs:
+
+```bash
+just verify            # fmt, clippy, test
+```
+
+After changing a configuration key, rewrite what is generated from it:
+
+```bash
+just regenerate        # docs/config.contract.json and the Dockerfile LABEL region
+```
 
 ## Configuration
 
-Configuration is layered by [terrace-config](https://github.com/TimSchoenle/terrace-config), so the
-Discord webhook can arrive as a mounted file rather than as an environment variable that shows up
-in `docker inspect` and in the environment of every child process.
-
+Configuration is layered by [terrace-config](https://github.com/TimSchoenle/terrace-config).
 Lowest precedence first:
 
 1. The defaults compiled into the config structs.
-2. TOML at `$NETCUP_OFFER_BOT_CONFIG`, defaulting to `./config.toml` — a file, or every `*.toml`
-   directly inside it when it names a directory, merged in file-name order. A missing file is not
-   an error.
+2. TOML at `$NETCUP_OFFER_BOT_CONFIG`, defaulting to `./config.toml`. A file, or every `*.toml`
+   directly inside it when it names a directory, merged in file-name order. A missing file is
+   not an error.
 3. `NETCUP_OFFER_BOT_`-prefixed environment variables.
 4. Every key-named file in `$NETCUP_OFFER_BOT_SECRETS_DIR`.
-5. `NETCUP_OFFER_BOT_<KEY>_FILE=/path`, which reads `<KEY>` from that path.
+5. `NETCUP_OFFER_BOT_<KEY>_FILE=/path`, which reads the value from that path.
 
-**Layers 3, 4 and 5 are mutually exclusive per key.** A key supplied by two of them fails the boot
-naming the key and both sources, rather than being resolved by precedence: a stale environment
-variable shadowing a webhook that has since been rotated would otherwise keep the bot posting to
-the old one, and the discrepancy would surface long after the deploy that caused it.
+The last three are mutually exclusive per key. Two of them supplying one key fails the boot,
+naming the key and both sources.
 
-**Nesting is `__`** — a single underscore is part of a field name. Case is folded,
-so `discord.webhook_url` is `NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL` as a variable and
+Nesting is `__`, because a single underscore is part of a field name. Case is folded, so
+`discord.webhook_url` is `NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL` as a variable and
 `discord__webhook_url` as a file name.
-
-Run with `NETCUP_OFFER_BOT_TELEMETRY__LOG_LEVEL=DEBUG` and the boot log names the layer
-every key was read from, which is what answers "the `Secret` is mounted and the bot is still posting
-to the old webhook".
-
-#### The variables read before the layers exist
-
-These decide what the layers *are*, so no layer can supply them.
-
-| Variable | Role | Default | Purpose |
-|---|---|---|---|
-| `NETCUP_OFFER_BOT_CONFIG` | config | `config.toml` | Names the TOML layer: a file, or a directory whose `*.toml` files are all merged in name order. |
-| `NETCUP_OFFER_BOT_SECRETS_DIR` | secrets dir | — | Names a directory of key-named files — a mounted Kubernetes `Secret` volume. Each file supplies the key its name spells. |
-
-#### Keys
 
 | TOML | Type | Environment | Default | Flags | Purpose |
 |---|---|---|---|---|---|
@@ -120,111 +170,76 @@ These decide what the layers *are*, so no layer can supply them.
 | `telemetry.log_level` | `Level` | `NETCUP_OFFER_BOT_TELEMETRY__LOG_LEVEL` | `INFO` | — | The maximum verbosity that reaches stdout: `TRACE`, `DEBUG`, `INFO`, `WARN` or `ERROR`, in any case. |
 | `telemetry.sentry_dsn` | `SecretString` | `NETCUP_OFFER_BOT_TELEMETRY__SENTRY_DSN` | unset | secret | Sentry DSN. Unset disables Sentry entirely. |
 
-Every key has two further spellings, both mechanical and both left out of the table to keep it inside
-a page: appending `_FILE` to the environment variable names a *file* holding the value,
-and the TOML path with `.` replaced by `__` is that key's file name inside the secrets
-directory.
+Run with `NETCUP_OFFER_BOT_TELEMETRY__LOG_LEVEL=DEBUG` and the boot log names the layer every
+key was read from. That is what answers "the `Secret` is mounted and the bot is still posting to
+the old webhook".
 
-#### `config.toml`
+[docs/CONFIGURATION.md](docs/CONFIGURATION.md) has the rest: the two variables the loader reads
+before any layer exists, both further spellings of every key, a `config.toml` carrying all of
+them, the secrets-directory recipes, and the contract each image publishes.
 
-Every key, commented out wherever leaving it out changes nothing, so this file and an empty one mean
-the same thing to the loader. What is left uncommented is exactly what has to be supplied — and each
-of those carries a placeholder rather than a value, so a copy left unedited fails at the key that was
-never filled in rather than running on it.
+## Operations
 
-```toml
-[discord]
-# Discord webhook the offers are posted to.
-# Type: SecretString
-# Required: nothing loads until this key is supplied.
-# Secret: the value below is a placeholder.
-webhook_url = "<secret>"
+### Metrics
 
-[feed]
-# Seconds between two RSS feed checks.
-# Type: u64
-# Required: nothing loads until this key is supplied.
-check_interval_secs = 0
+The Prometheus exporter serves `/metrics` on the address `metrics.ip` and `metrics.port` name,
+`127.0.0.1:9184` unless configured otherwise. Bind `0.0.0.0` to reach it from outside the
+container.
 
-[metrics]
-# Address the Prometheus exporter binds. `0.0.0.0` to reach it from outside the container.
-# Type: IpAddr
-# ip = "127.0.0.1"
+| Metric | Type | Labels | Reports |
+| --- | --- | --- | --- |
+| `feed_counter` | counter | `feed` | Items a round found to be new, counted before they are sent |
+| `feed_fetch_duration_seconds` | histogram | `feed` | Seconds one fetch of the feed took |
+| `feed_fetch_errors_total` | counter | `feed` | Fetches that failed, malformed payloads excluded |
+| `webhook_errors_total` | counter | `feed` | Items still undelivered after the fifth attempt |
 
-# Port the Prometheus exporter listens on.
-# Type: u16
-# port = 9184
+### State
 
-[telemetry]
-# The maximum verbosity that reaches stdout: `TRACE`, `DEBUG`, `INFO`, `WARN` or `ERROR`, in any case.
-# Type: Level
-# log_level = "INFO"
+`./data/feed_state.json` holds one UTC timestamp per feed and is rewritten only by a round that
+moved one. The image's working directory is `/app`, so the file a deployment has to keep is
+`/app/data/feed_state.json`.
 
-# Sentry DSN. Unset disables Sentry entirely.
-# Type: SecretString
-# Secret: the value below is a placeholder.
-# sentry_dsn = "<secret>"
-```
+### Runtime posture
 
-#### Secrets from files
+The runtime stage is `FROM scratch`. It carries the stripped binary, the CA bundle, the zone
+database, `/etc/passwd`, `/etc/group` and the offline copy of the configuration contract at
+`/config/contract.json`. The process runs as `1001:1001` and writes to `/app/data` and stdout,
+nothing else.
 
-A Kubernetes `Secret` mounted as a volume, one file per key — the provider follows the `..data`
-indirection a projected volume uses, so the mount works as written:
+## Compatibility
 
-```shell
-  docker run \
-    --name netcup-offer-bot \
-    -e NETCUP_OFFER_BOT_SECRETS_DIR="/run/secrets" \
-    -e NETCUP_OFFER_BOT_FEED__CHECK_INTERVAL_SECS="180" \
-    -v ./webhook:/run/secrets/discord__webhook_url:ro \
-    -v netcup-offer-bot-data:/app/data \
-    -d \
-    timmi6790/netcup-offer-bot:2.1.1
-  ```
+| | Supported |
+| --- | --- |
+| Rust | edition 2024 |
+| Platforms | `linux/amd64`, `linux/arm64` |
+| Helm chart | [`timschoenle/netcup-offer-bot`](https://github.com/TimSchoenle/helm-charts/tree/main/charts/netcup-offer-bot) |
 
-Or Docker's `_FILE` convention, for a single secret:
+## Documentation
 
-```shell
-  -e NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL_FILE="/run/secrets/webhook"
-  ```
+| Document | Purpose |
+| --- | --- |
+| [docs/CONFIGURATION.md](docs/CONFIGURATION.md) | Every configuration key this service reads, in every spelling that can supply it. |
+| [docs/config.contract.json](docs/config.contract.json) | — |
 
-#### The config contract
+## Contributing
 
-Every release publishes the table above as a machine-readable document, so a chart deploying this
-image can be checked against what the image actually reads rather than against a copy of this page
-that may have drifted. The committed copy is [`docs/config.contract.json`](docs/config.contract.json).
+Issues and pull requests are welcome. Commit messages follow Conventional Commits, which is what
+release-please reads to decide the next version, and `just verify` runs the checks a pull request
+is going to run anyway.
 
-Each image carries the same document three ways:
+Four things here are generated, and each names its source in its first lines: `README.md`,
+`docs/CONFIGURATION.md`, `docs/config.contract.json` and the `LABEL` region of the `Dockerfile`.
+`just regenerate` rewrites the last two. CI renders the first two, commits the result back to the
+branch, and fails a push to master that does not match.
 
-| Carrier | What it answers |
-|---|---|
-| `LABEL dev.terrace.config.*` in the image config blob | Does this image declare a contract, where is its offline copy, and which environment variables are its business — answerable in one registry request, with no layer pull |
-| `/config/contract.json` in the image | The offline copy, for a `docker save` tarball or an air-gapped mirror |
-| An OCI referrer of type `application/vnd.terrace.config-schema.v1+json` on the pushed digest, cosign-signed | The canonical fetch, tied to the exact build a chart pins |
+## Security
 
-All three are rendered from the same document by one program:
+Do not open a public issue for a vulnerability. [SECURITY.md](SECURITY.md) has the reporting
+route and the supported versions.
 
-```shell
-cargo run --features config-schema --example config-contract -- --format contract
-cargo run --features config-schema --example config-contract -- --format labels
-cargo run --features config-schema --example config-contract -- --format dockerfile
-```
-
-After changing a configuration key, regenerate the committed copy and the Dockerfile's `LABEL`
-region:
-
-```shell
-just regenerate
-```
-
-It rewrites `docs/config.contract.json` and the region between the `terrace-config:labels` markers
-in the `Dockerfile`, so a local run is the fix rather than a report. It writes and never checks —
-the checking is `TimSchoenle/actions/actions/rust/config-contract`, which diffs both against the
-configuration types on every pull request and then checks the built **image** against the labels
-the same generator emitted. The release workflow checks every platform in the index separately,
-before anything is attached to the digest or signed.
+The Discord webhook is the one credential this process holds, and anyone holding it can post to
+the channel. Supply it as a file rather than as an environment variable.
 
 ## License
 
-Distributed under the MIT License. See [LICENSE](https://github.com/TimSchoenle/netcup-offer-bot/blob/master/LICENSE)
-for more information.
+`GPL-3.0-only`. [LICENSE](LICENSE) has the terms.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,129 @@
+<!--
+Generated from .github/templates/CONFIGURATION.md.hbs. Edit that file, not this one.
+
+Rendered by the same job that renders README.md, from the same payload, so the tables here and
+the one there come out of one run of:
+
+    cargo run --quiet --features config-schema --example readme-variables
+
+Nothing in this comment may contain a mustache that is not a real reference.
+-->
+
+# Configuration
+
+Every configuration key this service reads, in every spelling that can supply it.
+
+The layering, the two required keys and the key table are in
+[the README](../README.md#configuration). What follows is the detail that does not fit on a page
+someone reads to decide whether to run this at all.
+
+## The variables read before the layers exist
+
+These decide what the layers are, so no layer can supply them.
+
+| Variable | Role | Default | Purpose |
+|---|---|---|---|
+| `NETCUP_OFFER_BOT_CONFIG` | config | `config.toml` | Names the TOML layer: a file, or a directory whose `*.toml` files are all merged in name order. |
+| `NETCUP_OFFER_BOT_SECRETS_DIR` | secrets dir | — | Names a directory of key-named files — a mounted Kubernetes `Secret` volume. Each file supplies the key its name spells. |
+
+## The two further spellings of every key
+
+Both are mechanical, which is why the key table names only the environment variable:
+
+- Appending `_FILE` to the environment variable makes it name a file holding the value.
+- The TOML path with `.` replaced by `__` is that key's file name inside
+  `$NETCUP_OFFER_BOT_SECRETS_DIR`.
+
+So `discord.webhook_url` is supplied by `NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL`, by
+`NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL_FILE=/path`, or by a file named `discord__webhook_url` in
+the secrets directory. Supplying it by two of the three fails the boot.
+
+## `config.toml`
+
+Every key, commented out wherever leaving it out changes nothing, so this file and an empty one
+mean the same thing to the loader. What is left uncommented is what has to be supplied, and each
+of those carries a placeholder rather than a value: a copy left unedited fails at the key nobody
+filled in rather than running on it.
+
+```toml
+[discord]
+# Discord webhook the offers are posted to.
+# Type: SecretString
+# Required: nothing loads until this key is supplied.
+# Secret: the value below is a placeholder.
+webhook_url = "<secret>"
+
+[feed]
+# Seconds between two RSS feed checks.
+# Type: u64
+# Required: nothing loads until this key is supplied.
+check_interval_secs = 0
+
+[metrics]
+# Address the Prometheus exporter binds. `0.0.0.0` to reach it from outside the container.
+# Type: IpAddr
+# ip = "127.0.0.1"
+
+# Port the Prometheus exporter listens on.
+# Type: u16
+# port = 9184
+
+[telemetry]
+# The maximum verbosity that reaches stdout: `TRACE`, `DEBUG`, `INFO`, `WARN` or `ERROR`, in any case.
+# Type: Level
+# log_level = "INFO"
+
+# Sentry DSN. Unset disables Sentry entirely.
+# Type: SecretString
+# Secret: the value below is a placeholder.
+# sentry_dsn = "<secret>"
+```
+
+## Secrets from files
+
+A Kubernetes `Secret` mounted as a volume, one file per key. The provider follows the `..data`
+indirection a projected volume uses, so the mount works as written:
+
+```bash
+docker run --rm \
+  -e NETCUP_OFFER_BOT_SECRETS_DIR="/run/secrets" \
+  -e NETCUP_OFFER_BOT_FEED__CHECK_INTERVAL_SECS=900 \
+  -v ./webhook:/run/secrets/discord__webhook_url:ro \
+  -v netcup-offer-bot-data:/app/data \
+  timmi6790/netcup-offer-bot:v2.1.1
+```
+
+For a single secret, Docker's own convention reaches the same place:
+
+```bash
+-e NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL_FILE="/run/secrets/webhook"
+```
+
+## The config contract
+
+Every release publishes the key table as a machine-readable document, so a chart deploying an
+image can be checked against the keys that image reads rather than against a copy of this page.
+The committed copy is [config.contract.json](config.contract.json).
+
+Each image carries the same document three ways:
+
+| Carrier | What it answers |
+| --- | --- |
+| `LABEL dev.terrace.config.*` in the image config blob | Does this image declare a contract, where is its offline copy, and which environment variables are its business. One registry request, no layer pull |
+| `/config/contract.json` in the image | The offline copy, for a `docker save` tarball or an air-gapped mirror |
+| An OCI referrer of type `application/vnd.terrace.config-schema.v1+json` on the pushed digest, cosign-signed | The canonical fetch, tied to the exact build a chart pins |
+
+One program renders all three:
+
+```bash
+cargo run --features config-schema --example config-contract -- --format contract
+cargo run --features config-schema --example config-contract -- --format labels
+cargo run --features config-schema --example config-contract -- --format dockerfile
+```
+
+After changing a configuration key, `just regenerate` rewrites the committed document and the
+region between the `terrace-config:labels` markers in the `Dockerfile`. It writes and never
+checks. The checking is `TimSchoenle/actions/actions/rust/config-contract`, which diffs both
+against the configuration types on every pull request and then checks the built image against
+the labels the same generator emitted, one platform at a time, before anything is attached to
+the digest or signed.

--- a/examples/readme-variables.rs
+++ b/examples/readme-variables.rs
@@ -1,18 +1,20 @@
-//! Emit the variables `.github/templates/README.md.hbs` is rendered with.
+//! Emit the half of the README payload that only this crate can answer.
 //!
-//! `README.md` is generated. This is the other half of that: the template holds the prose and
-//! this holds every value in it that is derivable from the code, so neither can drift from the
-//! crate it documents.
+//! `README.md` and `docs/CONFIGURATION.md` are generated. The template holds the prose, this
+//! holds the configuration facts derived from `Config`, and
+//! `TimSchoenle/actions/actions/common/readme-variables` derives the rest from `Cargo.toml` and
+//! `docs/`. That action reads this output through its `extra` input and deep-merges it, so
+//! anything it already derives is deliberately absent here: the repository slug, the branch, the
+//! release and the licence all reach the template as `repo.*` and `release.*`, and emitting a
+//! second copy under another name would be a second thing to keep true.
 //!
 //! ```text
 //! cargo run --quiet --features config-schema --example readme-variables
 //! ```
 //!
-//! One line of strict JSON on stdout, which is exactly what the `variables` input of
-//! `TimSchoenle/actions/actions/common/render-template-and-commit` takes. `serde_json` does the
-//! escaping, so a generated Markdown table full of `"`, `\` and newlines survives the trip
-//! through a workflow output verbatim — the reason this is a Rust example and not a shell
-//! script assembling JSON with `printf`.
+//! One line of strict JSON on stdout. `serde_json` does the escaping, so a generated Markdown
+//! table full of `"`, `\` and newlines survives the trip through a workflow output verbatim —
+//! the reason this is a Rust example and not a shell script assembling JSON with `printf`.
 //!
 //! It reads nothing from the environment, so it produces the same answer on a developer's
 //! machine and on a runner where none of the variables it describes are set. Rendering is
@@ -26,33 +28,18 @@ use netcup_offer_bot::config;
 use serde::Serialize;
 use terrace_config::schema::{Column, TomlExample};
 
-/// The GitHub repository, as `owner/name`.
-///
-/// Both the shields.io badges and the issue links are built from it, so moving the repository
-/// is one edit here rather than eight in the template.
-const REPOSITORY: &str = "TimSchoenle/netcup-offer-bot";
-
-/// The branch the permanent links in the README point at.
-const BRANCH: &str = "master";
-
 /// The Docker Hub repository the image is published to.
 ///
 /// Not derivable from the manifest: the namespace is a Docker Hub account rather than the
 /// GitHub owner, and the two names differ.
 const IMAGE: &str = "timmi6790/netcup-offer-bot";
 
-/// Everything `README.md.hbs` may reference.
+/// What the templates reference and no manifest holds.
 ///
-/// Strict mode is on in the workflow, so a template naming something absent here fails the
-/// render rather than silently emitting an empty table.
+/// Strict mode is on in the workflow, so a template naming something neither this struct nor
+/// the derived payload defines fails the render rather than silently emitting an empty table.
 #[derive(Serialize)]
 struct Variables {
-    /// The crate version, e.g. `2.0.1`.
-    version: &'static str,
-    /// The GitHub repository, as `owner/name`.
-    repository: &'static str,
-    /// The branch permanent links point at.
-    branch: &'static str,
     /// The Docker Hub repository, as `namespace/name`.
     image: &'static str,
     /// The prefix every configuration variable carries, e.g. `NETCUP_OFFER_BOT_`.
@@ -90,15 +77,12 @@ fn main() -> ExitCode {
 fn variables() -> Result<String, Box<dyn Error>> {
     let schema = config::schema()?;
 
-    // No preamble and no per-key spellings: the README states both, immediately above this
-    // snippet and in far more detail than a comment in a file can. What is left is what the
-    // section is for — the shape of the file, with every key in it.
+    // No preamble and no per-key spellings: `docs/CONFIGURATION.md` states both, immediately
+    // above this snippet and in far more detail than a comment in a file can. What is left is
+    // what the section is for — the shape of the file, with every key in it.
     let example = TomlExample::new().header(false).spellings(false);
 
     let variables = Variables {
-        version: env!("CARGO_PKG_VERSION"),
-        repository: REPOSITORY,
-        branch: BRANCH,
         image: IMAGE,
         prefix: schema.dialect.prefix.clone(),
         nesting_separator: schema.dialect.nesting_separator.clone(),


### PR DESCRIPTION
Brings this repository onto the README standard. The existing `.github/templates/README.md.hbs`
and the two-job `docs.yaml` were adapted, not replaced, and `examples/readme-variables.rs` is
still the source of every configuration table.

## What changed

**The page.** Canonical order throughout: provenance banner, `H1`, the manifest description, four
badges (release, build, coverage, licence, all links), what this is, quick start, table of
contents, features, installation, usage, configuration, operations, compatibility, documentation,
contributing, security, licence. The `<p align="center">` header block and its `<h3>` are gone, so
the page has one `H1` and no skipped levels. The old issues badge went with them; the Docker
version badge went because the release badge already answers that question. 245 rendered lines.

**The split.** The `config.toml` dump, the two-further-spellings rule, the secrets-directory
recipes and the config-contract detail moved to a new generated `docs/CONFIGURATION.md`. That is
what removed five `####` headings from the README outline. The key table stays on the README,
where a reader deciding whether to run this can see all six keys without a second click.

**The wiring.** The bespoke `Collect README variables` step became two steps in both jobs: the
existing generator into `steps.config.outputs.json`, then
`TimSchoenle/actions/actions/common/readme-variables@b5b5c9e` reading it through `extra`. Both
consumers now read `steps.variables.outputs.variables`. `render` feeds `render-template-and-commit`
(the pin already in the file) with `file_pattern: "README.md docs/CONFIGURATION.md"`, so one
verified commit carries both. `check` feeds `render-template` with `check: true`, once per file.
No new pin was invented.

**The manifest.** `Cargo.toml` gains `description` and `license`, because the payload reads both
from the manifest and refuses to read them from the GitHub API. Neither reaches
`docs/config.contract.json`, whose `app` block comes from constants in `src/config/contract.rs`;
verified by regenerating it and diffing.

**Three corrections.** The old page pinned `timmi6790/netcup-offer-bot:2.1.1`, but every tag
release-please has pushed carries a `v`, and Docker Hub lists no untagged-version tags. It offered
`latest`, which Docker Hub does not have. It said MIT over a GPLv3 `LICENSE`.

## Rendered locally, not hand-written

I ran the pinned `readme-variables` and `render-template` dist bundles under node against this
checkout, twice, then re-ran both with `check: true` and each reported its committed file up to
date. `cargo fmt --check`, `cargo clippy --all-features --all-targets -- -D warnings` and
`cargo test --all-features` all pass.

Both prose checks came out at 0, against budgets of 5 and 3. Sentence distribution over the
rendered README: n=59, mean 13.7, median 13, stdev 8.6, 31% under eight words.

## What a reviewer should check

1. **`license = "GPL-3.0-only"` is a judgement, not a fact I read.** `LICENSE` is the plain GPLv3
   text with no per-file headers, and nothing else in the repository declares a licence, so "only"
   versus "or-later" is undecided. It renders into the License section as `{{ repo.license }}`.
2. **The licence badge reads GitHub's detection, not the manifest.** `img.shields.io/github/license`
   was chosen over a typed badge because shields treats `-` as a field separator and the SPDX id
   would render wrong. The badge and the section could disagree if GitHub's detection differs.
3. **No MSRV.** `Cargo.toml` has no `rust-version`, so there is no MSRV badge and Compatibility
   says `edition 2024`. Adding a floor is a support claim nothing currently tests.
4. **The drift job keeps its id and name** (`check` / `README`) rather than the spec's
   `verify` / `readme`. It already renders with `check: true`; renaming it would change a check
   name something may point at.
5. **The docs index lags one run behind `docs/CONFIGURATION.md`'s first paragraph.** The payload is
   collected before that page is re-rendered, so a commit that changes its opening sentence renders
   the README's documentation table from the previous one. The `render` job's App-token commit
   re-triggers the workflow, so it converges before merge. Both files are committed converged here.
6. **Factual claims in the new prose, all read off the source rather than off the old README:** one
   feed, `https://www.netcup.com/rss/deals/de`; dedup by RFC 2822 `pubDate` against a watermark in
   `./data/feed_state.json`, with an absent file meaning everything is new; five delivery attempts,
   `retry-after` plus one second on `429` and `2^n` seconds on `5xx` or a connection error; a
   payload not beginning with an `rss` tag warned rather than counted; the four metric names and
   their `feed` label; `FROM scratch` running as `1001:1001`. The Dockerfile also creates an
   `appuser` at uid 1001 in a stage whose `/etc/passwd` is copied in, which is why the numeric
   pair has a name behind it, but the README claims only the numbers.
