### PR TITLE
docs: bring the doc comments onto the estate standard (contains a webhook refactor)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -106,6 +106,41 @@ jobs:
         uses: TimSchoenle/actions/actions/rust/clippy@dcfb46a6a17ad8565db74057ce60278953056ad5 # tag=actions-rust-clippy-v1.1.9
 
 
+  # rustdoc, with warnings fatal. `cargo check` never runs the rustdoc lints, so a broken
+  # intra-doc link or an unescaped backtick reaches the rendered page and nobody else's job
+  # notices. `missing_docs` is in the lint table and fails `check` on its own.
+  doc:
+    name: Doc
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to checkout the code
+    env:
+      RUSTDOCFLAGS: '-D warnings'
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Install stable toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+
+      # Both feature sets. The contract section of the `config` module documentation renders only
+      # under `config-schema`, and it links an item that does not exist without it, so each set
+      # has a link the other cannot break.
+      - name: Document
+        run: |
+          cargo doc --all-features --no-deps
+          cargo doc --no-deps
+
+      - name: Doctests
+        run: cargo test --doc --all-features
+
   # The reverse gate on the config contract: regenerate the committed document and the
   # Dockerfile's `LABEL` block from the Rust types and fail if either has drifted. A renamed key
   # or a renamed prefix then shows up in the pull request that renamed it, as a diff a reviewer

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,12 @@ edition = "2024"
 description = "Watches the netcup deals RSS feed and posts new offers to a Discord webhook."
 license = "GPL-3.0-only"
 
+# Inherited rather than written on the package, even though there is one crate here. A second
+# crate added next to this one starts held to the same lints instead of to whatever its own
+# manifest happens to say.
+[lints]
+workspace = true
+
 [lib]
 path = "src/lib.rs"
 
@@ -93,3 +99,29 @@ codegen-units = 1
 # symbols no object file defines and an "undefined reference to
 # `encoding_rs::UTF_8'" failure when ld links the musl binary.
 debug = "limited"
+
+# The documentation gate. `missing_docs` covers the crate root, every module, every exported
+# item and every public field; the `doc` job in `.github/workflows/build.yaml` runs rustdoc with
+# `-D warnings`, so the rustdoc-only lints below fail a pull request instead of scrolling past in
+# a local build.
+[workspace.lints.rust]
+missing_docs = "warn"
+
+# `missing_errors_doc` and `missing_panics_doc` are already inside `pedantic`. Named again so
+# that the next person to argue with `pedantic` knows these two were chosen, not swept in.
+[workspace.lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+missing_errors_doc = "warn"
+missing_panics_doc = "warn"
+doc_markdown = "warn"
+too_long_first_doc_paragraph = "warn"
+doc_link_with_quotes = "warn"
+doc_broken_link = "warn"
+doc_include_without_cfg = "warn"
+
+# Denied, not warned: a broken intra-doc link renders as the literal `[`Foo`]` on the page, so
+# the reader who needs it cannot see that it was meant to be a link.
+[workspace.lints.rustdoc]
+broken_intra_doc_links = "deny"
+private_intra_doc_links = "warn"
+unescaped_backticks = "warn"

--- a/docs/config.contract.json
+++ b/docs/config.contract.json
@@ -31,7 +31,7 @@
         "env": "NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL",
         "env_file": "NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL_FILE",
         "secrets_file": "discord__webhook_url",
-        "docs": "Discord webhook the offers are posted to.\n\nSecret: it is a bearer credential — anyone holding it can post to the channel — so it\nstays wrapped from the layer that read it to the request that uses it. `SecretString`\nrefuses to implement `Serialize` for that reason, which is why the field is skipped on\nthe way out; the key keeps its row and its `secret` flag either way, and a required key\nhas no default to print.",
+        "docs": "Discord webhook the offers are posted to.\n\nA bearer credential: anyone holding it can post to the channel. It stays wrapped from the\nlayer that read it to the request that uses it, so nothing between the two can print it.",
         "ty": "SecretString",
         "values": [],
         "constraint": {
@@ -154,7 +154,7 @@
         "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY_DSN",
         "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY_DSN_FILE",
         "secrets_file": "telemetry__sentry_dsn",
-        "docs": "Sentry DSN. Unset disables Sentry entirely.\n\nSecret: a DSN is a write credential for the project's event stream, and skipped on the\nway out for the reason [`DiscordConfig::webhook_url`] is. The key still reports itself\nas unset by default, which is the whole of what a table can usefully say about an\noptional secret.",
+        "docs": "Sentry DSN. Unset disables Sentry entirely.\n\nA write credential for the project's event stream, wrapped for the reason\n[`DiscordConfig::webhook_url`] is.",
         "ty": "SecretString",
         "values": [],
         "constraint": {
@@ -182,7 +182,7 @@
         "additionalProperties": false,
         "properties": {
           "webhook_url": {
-            "description": "Discord webhook the offers are posted to.\n\nSecret: it is a bearer credential — anyone holding it can post to the channel — so it\nstays wrapped from the layer that read it to the request that uses it. `SecretString`\nrefuses to implement `Serialize` for that reason, which is why the field is skipped on\nthe way out; the key keeps its row and its `secret` flag either way, and a required key\nhas no default to print.",
+            "description": "Discord webhook the offers are posted to.\n\nA bearer credential: anyone holding it can post to the channel. It stays wrapped from the\nlayer that read it to the request that uses it, so nothing between the two can print it.",
             "type": "string",
             "writeOnly": true
           }
@@ -226,7 +226,7 @@
             "description": "The maximum verbosity that reaches stdout: `TRACE`, `DEBUG`, `INFO`, `WARN` or `ERROR`,\nin any case.\n\nParsed at boot so an unusable value fails the load rather than the first log line.\n`DEBUG` and `TRACE` additionally print which layer supplied each configuration key."
           },
           "sentry_dsn": {
-            "description": "Sentry DSN. Unset disables Sentry entirely.\n\nSecret: a DSN is a write credential for the project's event stream, and skipped on the\nway out for the reason [`DiscordConfig::webhook_url`] is. The key still reports itself\nas unset by default, which is the whole of what a table can usefully say about an\noptional secret.",
+            "description": "Sentry DSN. Unset disables Sentry entirely.\n\nA write credential for the project's event stream, wrapped for the reason\n[`DiscordConfig::webhook_url`] is.",
             "type": "string",
             "writeOnly": true
           }

--- a/examples/config-contract.rs
+++ b/examples/config-contract.rs
@@ -1,4 +1,4 @@
-//! Emit the config contract, and the image labels that make it discoverable.
+//! Emits the config contract, and the image labels that make it discoverable.
 //!
 //! ```text
 //! cargo run --quiet --features config-schema --example config-contract -- --format contract    > docs/config.contract.json

--- a/examples/readme-variables.rs
+++ b/examples/readme-variables.rs
@@ -1,4 +1,4 @@
-//! Emit the half of the README payload that only this crate can answer.
+//! Emits the half of the README payload that only this crate can answer.
 //!
 //! `README.md` and `docs/CONFIGURATION.md` are generated. The template holds the prose, this
 //! holds the configuration facts derived from `Config`, and
@@ -69,7 +69,7 @@ fn main() -> ExitCode {
     }
 }
 
-/// Build the payload.
+/// Builds the payload.
 ///
 /// # Errors
 /// Returns an error if the schema cannot be built or the payload cannot be encoded. Neither

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,16 +20,24 @@
 //! Under the `config-schema` feature these structs also derive `Describe`, and the
 //! configuration tables in `README.md` are generated from what it reports: every key path,
 //! every environment spelling, every default, and the *first paragraph* of each field's doc
-//! comment. Write that paragraph for an operator setting the value — anything below it stays
+//! comment. Write that paragraph for an operator setting the value. Anything below it stays
 //! here, for whoever reads the type.
 //!
-//! # The contract this image publishes
-//!
-//! Under the same feature, [`contract`] renders these types as the document the container build
-//! embeds in the image and attaches to its pushed digest, and the `dev.terrace.config.*` labels
-//! that make it discoverable. A key added below is a key the deployment side learns about in the
-//! same commit; `docs/config.contract.json` is the committed copy, and CI fails a pull request
-//! that changes one without the other.
+// Gated rather than written as `//!`, because the link below is to an item that only exists
+// under the feature and `rustdoc::broken_intra_doc_links` is denied. The section renders in the
+// documentation job, which builds with `--all-features`.
+#![cfg_attr(
+    feature = "config-schema",
+    doc = r"
+# The contract this image publishes
+
+Under the same feature, [`contract`] renders these types as the document the container build
+embeds in the image and attaches to its pushed digest, and the `dev.terrace.config.*` labels
+that make it discoverable. A key added below is a key the deployment side learns about in the
+same commit; `docs/config.contract.json` is the committed copy, and CI fails a pull request
+that changes one without the other.
+"
+)]
 
 #[cfg(feature = "config-schema")]
 pub mod contract;
@@ -50,32 +58,35 @@ const DEFAULT_METRIC_PORT: u16 = 9184;
 const DEFAULT_LOG_LEVEL: Level = Level::INFO;
 
 /// Everything the process reads before it starts.
-///
-/// The two derives behind `config-schema` are the documentation job's: `Describe` reports the
-/// keys and `Serialize` is what the generator reads the `Default` column out of. Neither has
-/// another reason to exist here, since the loader only ever *deserialises* — and the
-/// `#[config(...)]` attributes are gated the same way, because a helper attribute without the
-/// derive that declares it is a compile error rather than a no-op.
+// Not rustdoc: the two derives behind `config-schema` are the documentation job's, and a caller
+// of this type does nothing differently for knowing it. `Describe` reports the keys, `Serialize`
+// is what the generator reads the `Default` column out of, and the loader itself only ever
+// deserialises. The `#[config(...)]` attributes are gated the same way, because a helper
+// attribute without the derive that declares it is a compile error and not a no-op.
 #[derive(Debug, Deserialize)]
 #[cfg_attr(
     feature = "config-schema",
     derive(serde::Serialize, terrace_config::schema::Describe)
 )]
 pub struct Config {
+    /// No default; the boot fails without a webhook.
     #[cfg_attr(feature = "config-schema", config(nested))]
     pub discord: DiscordConfig,
+    /// Required. There is no default poll interval.
     #[cfg_attr(feature = "config-schema", config(nested))]
     pub feed: FeedConfig,
+    /// Absent binds `127.0.0.1:9184`.
     #[serde(default)]
     #[cfg_attr(feature = "config-schema", config(nested))]
     pub metrics: MetricsConfig,
+    /// Omitted, the process logs at `INFO` and stays out of Sentry.
     #[serde(default)]
     #[cfg_attr(feature = "config-schema", config(nested))]
     pub telemetry: TelemetryConfig,
 }
 
 impl Config {
-    /// Load the configuration from every layer.
+    /// Loads the configuration from every layer.
     ///
     /// # Errors
     /// Returns [`ConfigError`] if a required value is missing, a value fails to parse, a
@@ -112,7 +123,7 @@ impl Default for Config {
     }
 }
 
-/// The configuration surface as a schema, with its `Default` column filled in.
+/// Renders the configuration surface as a schema, with its `Default` column filled in.
 ///
 /// The generated half of `README.md`. It reads nothing from the environment, so it produces
 /// the same answer on a developer's machine and on a runner where none of the variables it
@@ -135,11 +146,12 @@ pub fn schema() -> Result<terrace_config::schema::Schema, ConfigError> {
 pub struct DiscordConfig {
     /// Discord webhook the offers are posted to.
     ///
-    /// Secret: it is a bearer credential — anyone holding it can post to the channel — so it
-    /// stays wrapped from the layer that read it to the request that uses it. `SecretString`
-    /// refuses to implement `Serialize` for that reason, which is why the field is skipped on
-    /// the way out; the key keeps its row and its `secret` flag either way, and a required key
-    /// has no default to print.
+    /// A bearer credential: anyone holding it can post to the channel. It stays wrapped from the
+    /// layer that read it to the request that uses it, so nothing between the two can print it.
+    // Not rustdoc: the paragraph above is rendered into the README table for an operator. Why the
+    // field is skipped on the way out is for whoever changes this line: `SecretString` has no
+    // `Serialize` impl, and the generated table loses nothing, since the key keeps its row and
+    // its `secret` flag and a required key has no default to print.
     #[serde(skip_serializing)]
     #[cfg_attr(feature = "config-schema", config(secret))]
     pub webhook_url: SecretString,
@@ -160,7 +172,7 @@ pub struct FeedConfig {
 }
 
 impl FeedConfig {
-    /// The poll interval as a [`Duration`].
+    /// Returns the poll interval as a [`Duration`].
     #[must_use]
     pub fn check_interval(&self) -> Duration {
         Duration::from_secs(self.check_interval_secs)
@@ -191,7 +203,7 @@ impl Default for MetricsConfig {
 }
 
 impl MetricsConfig {
-    /// The address the exporter binds.
+    /// Returns the address the exporter binds.
     #[must_use]
     pub fn socket(&self) -> SocketAddr {
         SocketAddr::new(self.ip, self.port)
@@ -218,10 +230,11 @@ pub struct TelemetryConfig {
     pub log_level: Level,
     /// Sentry DSN. Unset disables Sentry entirely.
     ///
-    /// Secret: a DSN is a write credential for the project's event stream, and skipped on the
-    /// way out for the reason [`DiscordConfig::webhook_url`] is. The key still reports itself
-    /// as unset by default, which is the whole of what a table can usefully say about an
-    /// optional secret.
+    /// A write credential for the project's event stream, wrapped for the reason
+    /// [`DiscordConfig::webhook_url`] is.
+    // Not rustdoc: skipped on the way out for the same reason as `webhook_url`. The key still
+    // reports itself as unset by default, which is all a table can usefully say about an
+    // optional secret.
     #[serde(skip_serializing)]
     #[cfg_attr(feature = "config-schema", config(secret))]
     pub sentry_dsn: Option<SecretString>,
@@ -236,7 +249,7 @@ impl Default for TelemetryConfig {
     }
 }
 
-/// Parse a [`Level`] from any layer's string form.
+/// Parses a [`Level`] from any layer's string form.
 ///
 /// The error names the value and the accepted set, because the previous system's failure —
 /// `LOG_LEVEL=FATAL`, a level `tracing` does not have — read only as "invalid level".
@@ -252,12 +265,16 @@ where
     })
 }
 
-/// Render a [`Level`] the way every layer spells it.
+/// Renders a [`Level`] the way every layer spells it.
 ///
 /// The inverse of [`deserialize_level`], and reachable only from the schema generator: nothing
 /// in this process serialises a `Config`, and `tracing::Level` has no `Serialize` impl of its
 /// own for either of them to use.
 #[cfg(feature = "config-schema")]
+#[allow(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "serde hands a `serialize_with` hook the field by reference"
+)]
 fn serialize_level<S>(level: &Level, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,

--- a/src/config/contract.rs
+++ b/src/config/contract.rs
@@ -2,7 +2,7 @@
 //!
 //! The document a chart is validated against: every configuration key in every spelling that can
 //! supply it, the same keys as a JSON Schema, and the surface outside the loader's namespace. It
-//! is built from [`schema`](super::schema), so it describes the [`Config`](super::Config) this
+//! is built from [`schema`], so it describes the [`Config`](super::Config) this
 //! binary deserialises rather than a second account of it — and the three
 //! `dev.terrace.config.*` labels an image carries are rendered from the same [`Contract`], which
 //! is what stops a label from naming a prefix the loader does not read.
@@ -28,7 +28,7 @@ pub const APP_NAME: &str = "netcup-offer-bot";
 /// Where the source lives.
 pub const SOURCE: &str = "https://github.com/TimSchoenle/netcup-offer-bot";
 
-/// Which build a contract describes, before the caller states a release.
+/// Names the build a contract describes, before the caller states a release.
 ///
 /// The release is the caller's to add, because this crate has no honest answer for it.
 /// `CARGO_PKG_VERSION` looks like one and is not: it would go stale the moment release-please
@@ -40,8 +40,8 @@ pub fn app() -> App {
     App::new(APP_NAME).source(SOURCE)
 }
 
-/// The whole contract this image publishes: every configuration key, and everything else it
-/// reads.
+/// Builds the whole contract this image publishes: every configuration key, and everything else
+/// it reads.
 ///
 /// The external surface is two ignore patterns and no declared variables, and that is the honest
 /// answer for this image rather than an unfinished list. The chart passes configuration as
@@ -58,7 +58,7 @@ pub fn contract(app: App) -> Result<Contract, ConfigError> {
     schema()?.into_contract(app).external(external()).build()
 }
 
-/// The environment this image reads that the loader does not own.
+/// Declares the environment this image reads that the loader does not own.
 ///
 /// Two ignore patterns and no declared variables, for the reason [`contract`] gives. Public
 /// because the generator hands it to `Cli::contract_with` and this function builds a contract

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -19,7 +19,7 @@ pub use terrace_config::Error as ConfigError;
 /// The prefix every configuration variable carries.
 const PREFIX: &str = "NETCUP_OFFER_BOT_";
 
-/// The loader the process boots through.
+/// Builds the loader the process boots through.
 ///
 /// Layers, lowest precedence first: struct defaults, TOML at `$NETCUP_OFFER_BOT_CONFIG` (a
 /// file, or every `*.toml` in it if it names a directory), `NETCUP_OFFER_BOT_`-prefixed
@@ -45,7 +45,7 @@ pub fn terrace() -> Terrace {
         .secrets_dir_var("NETCUP_OFFER_BOT_SECRETS_DIR")
 }
 
-/// Load a typed configuration.
+/// Loads a typed configuration.
 ///
 /// # Errors
 /// Returns [`ConfigError`] if a required value is missing, a value fails to parse, a
@@ -55,7 +55,7 @@ pub fn load<T: DeserializeOwned>() -> Result<T, ConfigError> {
     terrace().load()
 }
 
-/// Which layer supplied each key, re-read at the moment it is called.
+/// Reports which layer supplied each key, re-read at the moment it is called.
 ///
 /// Holds no configuration value — not redacted on the way out, never recorded — so the report
 /// is safe to log in full. It is what answers "the `Secret` is mounted and the bot is still
@@ -69,7 +69,7 @@ pub fn explain() -> Result<Explanation, ConfigError> {
     terrace().explain()
 }
 
-/// The configuration surface as a schema, for the documentation job.
+/// Describes the configuration surface as a schema, for the documentation job.
 ///
 /// Reads nothing from the environment, so it produces the same answer on a runner where none
 /// of the variables it describes are set.

--- a/src/discord_webhook.rs
+++ b/src/discord_webhook.rs
@@ -1,3 +1,8 @@
+//! Delivery to Discord. One RSS item becomes one embed, and the retry policy wraps the POST.
+//!
+//! A `429` waits out the `retry-after` header, a `5xx` or a dropped connection backs off
+//! exponentially, and any other unsuccessful status fails the item without a retry.
+
 use std::time::Duration;
 
 use reqwest::{Response, StatusCode};
@@ -10,19 +15,31 @@ use crate::Result;
 use crate::error::Error;
 use crate::feed::Feed;
 
+/// Attempts one item gets before it is given up on.
+///
+/// Five spends 2, 4, 8 and 16 seconds of backoff, so half a minute of Discord being unavailable
+/// costs the item that was in flight.
 const MAX_ATTEMPTS: u32 = 5;
 
+/// Waited out when Discord rate limits without saying for how long.
 const DEFAULT_RETRY_AFTER: Duration = Duration::from_secs(1);
 
+/// Added to whatever `retry-after` asks for, so a wait rounded down by either side does not land
+/// the retry back inside the window.
 const RETRY_AFTER_BUFFER: Duration = Duration::from_secs(1);
 
+/// One Discord webhook, ready to post to.
 #[derive(Debug)]
 pub struct DiscordWebhook {
     url: SecretString,
+    // A plain client rather than the checker's traced one: `SpanBackendWithUrl` records the
+    // request URL on the span, and here the URL is the credential.
     client: reqwest::Client,
 }
 
 impl DiscordWebhook {
+    /// Builds a webhook that posts to `url`.
+    #[must_use]
     pub fn new(url: SecretString) -> Self {
         DiscordWebhook {
             url,
@@ -30,6 +47,17 @@ impl DiscordWebhook {
         }
     }
 
+    /// Posts one item as an embed carrying its title, description, link, publication date and
+    /// categories.
+    ///
+    /// Returns `true`, always: an undelivered item is an error rather than `false`. Sleeps
+    /// between attempts, so a Discord that keeps answering `5xx` holds this for thirty seconds
+    /// before it gives up, and a `429` holds it for whatever `retry-after` asks for, uncapped.
+    ///
+    /// # Errors
+    /// Fails when all five attempts have been spent on rate limits, server errors or connection
+    /// failures, and immediately on any other unsuccessful status. A `400` from a malformed embed
+    /// is in the second group and is not retried.
     #[tracing::instrument(skip(self, feed, item))]
     pub async fn send_discord_message(&self, feed: &Feed, item: Item) -> Result<bool> {
         info!(
@@ -44,6 +72,7 @@ impl DiscordWebhook {
         self.send_with_retry(&payload).await
     }
 
+    /// Posts the payload until it lands or the attempts run out.
     async fn send_with_retry(&self, payload: &serde_json::Value) -> Result<bool> {
         let mut attempts = 0;
 
@@ -110,6 +139,8 @@ impl DiscordWebhook {
     }
 }
 
+/// Builds the embed for one item, with `No title` and `No description` standing in for what the
+/// item left out.
 fn build_embed(item: &Item) -> serde_json::Value {
     let mut embed = json!({
         "title": item.title().unwrap_or("No title"),
@@ -151,6 +182,7 @@ fn build_embed(item: &Item) -> serde_json::Value {
     embed
 }
 
+/// Wraps the embed in a payload posted under the feed's name, not the webhook's own.
 fn build_payload(feed: Feed, embed: &serde_json::Value) -> serde_json::Value {
     json!({
         "username": format!("Feed - {}", feed.name()),
@@ -158,6 +190,11 @@ fn build_payload(feed: Feed, embed: &serde_json::Value) -> serde_json::Value {
     })
 }
 
+/// Reads `retry-after`, or [`DEFAULT_RETRY_AFTER`] when the header is missing or is not a number
+/// of seconds.
+///
+/// Fractions are kept. Truncating a `0.75` to zero would retry inside the window the header
+/// describes.
 fn retry_after(response: &Response) -> Duration {
     response
         .headers()
@@ -168,6 +205,7 @@ fn retry_after(response: &Response) -> Duration {
         .unwrap_or(DEFAULT_RETRY_AFTER)
 }
 
+/// Doubles from two seconds: two on the first retry, then four, eight and sixteen.
 fn backoff(attempts: u32) -> Duration {
     Duration::from_secs(2u64.pow(attempts))
 }

--- a/src/discord_webhook.rs
+++ b/src/discord_webhook.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use reqwest::StatusCode;
+use reqwest::{Response, StatusCode};
 use rss::Item;
 use secrecy::{ExposeSecret, SecretString};
 use serde_json::json;
@@ -9,6 +9,12 @@ use tokio::time::sleep;
 use crate::Result;
 use crate::error::Error;
 use crate::feed::Feed;
+
+const MAX_ATTEMPTS: u32 = 5;
+
+const DEFAULT_RETRY_AFTER: Duration = Duration::from_secs(1);
+
+const RETRY_AFTER_BUFFER: Duration = Duration::from_secs(1);
 
 #[derive(Debug)]
 pub struct DiscordWebhook {
@@ -32,131 +38,136 @@ impl DiscordWebhook {
             item.title().unwrap_or("No title")
         );
 
-        let embed = self.build_embed(&item);
-        let payload = self.build_payload(feed, embed);
+        let embed = build_embed(&item);
+        let payload = build_payload(*feed, &embed);
 
         self.send_with_retry(&payload).await
     }
 
-    fn build_embed(&self, item: &Item) -> serde_json::Value {
-        let mut embed = json!({
-            "title": item.title().unwrap_or("No title"),
-            "description": item.description().unwrap_or("No description"),
-        });
-
-        if let Some(url) = item.link() {
-            embed["url"] = json!(url);
-        }
-
-        let mut fields = Vec::new();
-
-        if let Some(date) = item.pub_date() {
-            fields.push(json!({
-                "name": "Date",
-                "value": date,
-                "inline": false
-            }));
-        }
-
-        let categories = item
-            .categories()
-            .iter()
-            .map(|category| category.name.clone())
-            .collect::<Vec<String>>()
-            .join(", ");
-        if !categories.is_empty() {
-            fields.push(json!({
-                "name": "Categories",
-                "value": categories,
-                "inline": false
-            }));
-        }
-
-        if !fields.is_empty() {
-            embed["fields"] = json!(fields);
-        }
-
-        embed
-    }
-
-    fn build_payload(&self, feed: &Feed, embed: serde_json::Value) -> serde_json::Value {
-        json!({
-            "username": format!("Feed - {}", feed.name()),
-            "embeds": [embed]
-        })
-    }
-
     async fn send_with_retry(&self, payload: &serde_json::Value) -> Result<bool> {
         let mut attempts = 0;
-        const MAX_ATTEMPTS: u32 = 5;
 
         loop {
             attempts += 1;
-            let response = self
+            let backoff = match self
                 .client
                 // codeql[rust/cleartext-transmission]
                 .post(self.url.expose_secret())
                 .json(payload)
                 .send()
-                .await;
+                .await
+            {
+                Ok(response) if response.status().is_success() => return Ok(true),
+                Ok(response) if response.status() == StatusCode::TOO_MANY_REQUESTS => {
+                    if attempts >= MAX_ATTEMPTS {
+                        return Err(Error::custom("Max retries exceeded for rate limit"));
+                    }
 
-            match response {
-                Ok(res) => {
-                    if res.status().is_success() {
-                        return Ok(true);
-                    } else if res.status() == StatusCode::TOO_MANY_REQUESTS {
-                        if attempts >= MAX_ATTEMPTS {
-                            return Err(Error::custom(
-                                "Max retries exceeded for rate limit".to_string(),
-                            ));
-                        }
-
-                        let wait_seconds = if let Some(h) = res.headers().get("retry-after") {
-                            if let Ok(s) = h.to_str() {
-                                s.parse::<f64>().unwrap_or(1.0) as u64
-                            } else {
-                                1
-                            }
-                        } else {
-                            1
-                        };
-
-                        warn!(
-                            "Rate limited. Waiting for {} seconds before retry {}/{}",
-                            wait_seconds, attempts, MAX_ATTEMPTS
-                        );
-                        sleep(Duration::from_secs(wait_seconds + 1)).await; // Add buffer
-                        continue;
-                    } else if res.status().is_server_error() {
-                        if attempts >= MAX_ATTEMPTS {
-                            return Err(Error::custom(format!("Server error: {}", res.status())));
-                        }
-                        warn!(
-                            "Server error {}. Retrying {}/{}",
-                            res.status(),
-                            attempts,
-                            MAX_ATTEMPTS
-                        );
-                        sleep(Duration::from_secs(2u64.pow(attempts))).await; // Exponential backoff
-                        continue;
-                    } else {
+                    let wait = retry_after(&response) + RETRY_AFTER_BUFFER;
+                    warn!(
+                        "Rate limited. Waiting for {:?} before retry {}/{}",
+                        wait, attempts, MAX_ATTEMPTS
+                    );
+                    wait
+                }
+                Ok(response) if response.status().is_server_error() => {
+                    if attempts >= MAX_ATTEMPTS {
                         return Err(Error::custom(format!(
-                            "Failed to send webhook: {}",
-                            res.status()
+                            "Server error: {}",
+                            response.status()
                         )));
                     }
+
+                    warn!(
+                        "Server error {}. Retrying {}/{}",
+                        response.status(),
+                        attempts,
+                        MAX_ATTEMPTS
+                    );
+                    backoff(attempts)
+                }
+                Ok(response) => {
+                    return Err(Error::custom(format!(
+                        "Failed to send webhook: {}",
+                        response.status()
+                    )));
                 }
                 Err(e) => {
                     if attempts >= MAX_ATTEMPTS {
                         return Err(Error::custom(e.to_string()));
                     }
+
                     warn!(
                         "Network error: {}. Retrying {}/{}",
                         e, attempts, MAX_ATTEMPTS
                     );
-                    sleep(Duration::from_secs(2u64.pow(attempts))).await;
+                    backoff(attempts)
                 }
-            }
+            };
+
+            sleep(backoff).await;
         }
     }
+}
+
+fn build_embed(item: &Item) -> serde_json::Value {
+    let mut embed = json!({
+        "title": item.title().unwrap_or("No title"),
+        "description": item.description().unwrap_or("No description"),
+    });
+
+    if let Some(url) = item.link() {
+        embed["url"] = json!(url);
+    }
+
+    let mut fields = Vec::new();
+
+    if let Some(date) = item.pub_date() {
+        fields.push(json!({
+            "name": "Date",
+            "value": date,
+            "inline": false
+        }));
+    }
+
+    let categories = item
+        .categories()
+        .iter()
+        .map(|category| category.name.clone())
+        .collect::<Vec<String>>()
+        .join(", ");
+    if !categories.is_empty() {
+        fields.push(json!({
+            "name": "Categories",
+            "value": categories,
+            "inline": false
+        }));
+    }
+
+    if !fields.is_empty() {
+        embed["fields"] = json!(fields);
+    }
+
+    embed
+}
+
+fn build_payload(feed: Feed, embed: &serde_json::Value) -> serde_json::Value {
+    json!({
+        "username": format!("Feed - {}", feed.name()),
+        "embeds": [embed]
+    })
+}
+
+fn retry_after(response: &Response) -> Duration {
+    response
+        .headers()
+        .get("retry-after")
+        .and_then(|header| header.to_str().ok())
+        .and_then(|value| value.parse::<f64>().ok())
+        .and_then(|seconds| Duration::try_from_secs_f64(seconds).ok())
+        .unwrap_or(DEFAULT_RETRY_AFTER)
+}
+
+fn backoff(attempts: u32) -> Duration {
+    Duration::from_secs(2u64.pow(attempts))
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,8 +35,8 @@ fn is_expected_feed_parse_message(message: &str) -> bool {
 }
 
 impl Error {
-    pub fn custom<T: ToString>(msg: T) -> Self {
-        Self::Custom(msg.to_string())
+    pub fn custom(msg: impl Into<String>) -> Self {
+        Self::Custom(msg.into())
     }
 
     pub fn is_expected_feed_parse_error(&self) -> bool {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,9 @@
+//! One error type over everything a round can hit, so this crate matches on one type and not on
+//! five libraries' error types.
+
 use thiserror::Error;
 
+/// Anything that went wrong between reading the configuration and posting an item.
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Config error: {0}")]
@@ -24,10 +28,17 @@ pub enum Error {
     Prometheus(#[from] prometheus::Error),
     #[error("Prometheus exporter error")]
     PrometheusExport(#[from] prometheus_exporter::Error),
+    /// An unsuccessful HTTP status, or retries running out.
     #[error("Custom: {0}")]
     Custom(String),
 }
 
+/// Reports whether a parse failure is the one netcup produces when the deals list is empty.
+///
+/// Matched on the rendered message rather than on the `rss::Error::InvalidStartTag` behind it, so
+/// a release of `rss` that rewords the sentence turns this into `false` and puts the empty-feed
+/// case back into Sentry. Case-folded because the wording belongs to that crate and is not part of
+/// its API.
 fn is_expected_feed_parse_message(message: &str) -> bool {
     message
         .to_ascii_lowercase()
@@ -35,10 +46,15 @@ fn is_expected_feed_parse_message(message: &str) -> bool {
 }
 
 impl Error {
+    /// Builds an error carrying a message and nothing else.
     pub fn custom(msg: impl Into<String>) -> Self {
         Self::Custom(msg.into())
     }
 
+    /// Reports whether this is the empty-feed payload rather than a fetch worth counting.
+    ///
+    /// [`FeedChecker::check_feed`](crate::FeedChecker::check_feed) logs a `true` at `WARN`, which
+    /// keeps it out of Sentry and out of `feed_fetch_errors_total`.
     pub fn is_expected_feed_parse_error(&self) -> bool {
         match self {
             Self::Rss(err) => is_expected_feed_parse_message(&err.to_string()),

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -1,3 +1,8 @@
+//! The feeds this process watches, and the fetch that turns one into a parsed channel.
+//!
+//! The set is compiled in. No configuration key names a feed, so a second source is a code change
+//! that also decides what the new variant is called in the metrics and in Discord.
+
 use std::fmt;
 
 use reqwest_middleware::ClientWithMiddleware;
@@ -5,28 +10,50 @@ use rss::Channel;
 use rss::validation::Validate;
 use serde::{Deserialize, Serialize};
 
+/// One RSS source, with its address.
+///
+/// Serialised as the key of the watermark file, so renaming a variant leaves a file that no
+/// longer parses and panics the boot in
+/// [`FeedChecker::from_config`](crate::FeedChecker::from_config).
 #[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize, Eq, Hash)]
 pub enum Feed {
+    /// The netcup deals feed, in German.
     Netcup,
 }
 
 impl Feed {
+    /// Returns the feed's label, used as the `feed` value on every metric and as the name
+    /// Discord shows the post under.
+    #[must_use]
     pub fn name(self) -> &'static str {
         match self {
             Feed::Netcup => "Netcup",
         }
     }
 
+    /// Returns the address the feed is fetched from.
+    #[must_use]
     pub fn url(self) -> &'static str {
         match self {
             Feed::Netcup => "https://www.netcup.com/rss/deals/de",
         }
     }
 
+    /// Iterates every feed, in declaration order.
     pub fn iter() -> impl Iterator<Item = Self> {
         [Feed::Netcup].into_iter()
     }
 
+    /// Fetches the feed and returns it parsed and validated.
+    ///
+    /// The whole body is read into memory before parsing starts, and nothing here sets a timeout,
+    /// so a stalled connection stalls the round it is in for as long as `client` allows.
+    ///
+    /// # Errors
+    /// Fails if the request does not complete, if the body does not parse as RSS, or if the
+    /// document fails RSS validation. netcup answers an empty deals list with a body that does not
+    /// begin with an `rss` tag, and [`FeedChecker::check_feed`](crate::FeedChecker::check_feed) is
+    /// the one place that tells that apart from a fetch worth counting.
     #[tracing::instrument]
     pub async fn fetch(&self, client: &ClientWithMiddleware) -> crate::Result<Channel> {
         let content = client.get(self.url()).send().await?.bytes().await?;

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -11,13 +11,13 @@ pub enum Feed {
 }
 
 impl Feed {
-    pub fn name(&self) -> &str {
+    pub fn name(self) -> &'static str {
         match self {
             Feed::Netcup => "Netcup",
         }
     }
 
-    pub fn url(&self) -> &str {
+    pub fn url(self) -> &'static str {
         match self {
             Feed::Netcup => "https://www.netcup.com/rss/deals/de",
         }

--- a/src/feed_state.rs
+++ b/src/feed_state.rs
@@ -1,3 +1,12 @@
+//! The watermark each feed has been posted up to, and the file that holds it.
+//!
+//! One publication date per feed, written as whole seconds since the epoch in one JSON file. A
+//! deployment that loses the file reposts what the feed still lists, which is why a missing file
+//! is the first-run case here and never an error.
+//!
+//! Nothing locks the file. Two containers over one volume would overwrite each other's dates, and
+//! the process is written on the assumption that it holds the volume alone.
+
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -8,14 +17,25 @@ use serde::{Deserialize, Serialize};
 
 use crate::feed::Feed;
 
+/// Where the watermark file lives, relative to the working directory.
+///
+/// The image sets that to `/app` and the README mounts a volume at `/app/data`, so this is the
+/// one path a deployment has to keep across restarts.
 const FEED_STATE_FILE: &str = "./data/feed_state.json";
 
+/// Every feed's watermark, as the file holds them.
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct FeedStates {
     feeds: HashMap<Feed, FeedState>,
 }
 
 impl FeedStates {
+    /// Reads [`FEED_STATE_FILE`], or starts empty and creates the directory it will be written
+    /// to.
+    ///
+    /// # Errors
+    /// Fails if the file exists and cannot be read or does not parse, or if the directory cannot
+    /// be created.
     pub fn load() -> crate::Result<Self> {
         let path = Path::new(FEED_STATE_FILE);
         FeedStates::load_from_path(path)
@@ -29,7 +49,6 @@ impl FeedStates {
             let content = std::fs::read_to_string(file)?;
             serde_json::from_str(&content).map_err(Into::into)
         } else {
-            // Ensure that the path exists
             let prefix = file.parent().ok_or("Invalid FEED_SATE_FILE path")?;
             std::fs::create_dir_all(prefix)?;
 
@@ -45,10 +64,17 @@ impl FeedStates {
         }
     }
 
+    /// Returns the feed's watermark, inserting an empty one the first time a feed is seen.
     pub fn get_feed_or_create(&mut self, feed: Feed) -> &mut FeedState {
         self.feeds.entry(feed).or_default()
     }
 
+    /// Returns the items dated after the feed's watermark, in the order they arrived, and moves
+    /// the watermark to the newest of them.
+    ///
+    /// An item is dropped, and the drop logged, when it carries no `pubDate` or one that is not
+    /// RFC 2822. The watermark moves before any of these items has been delivered, so a caller
+    /// that fails to send one does not get it offered again.
     #[tracing::instrument]
     pub fn get_new_feed(&mut self, feed: Feed, items: Vec<Item>) -> Vec<Item> {
         if items.is_empty() {
@@ -89,9 +115,7 @@ impl FeedStates {
             }
         }
 
-        // Store new last date if found
         if let Some(date) = last_date {
-            // Convert to UTC
             let date = date.with_timezone(&Utc);
             feed_state.set_last_update(date);
         }
@@ -99,10 +123,12 @@ impl FeedStates {
         sorted
     }
 
+    /// Reports whether any watermark has moved since the last save.
     pub fn is_dirty(&self) -> bool {
         self.feeds.values().any(|state| state.dirty)
     }
 
+    /// Writes the watermarks to [`FEED_STATE_FILE`], or does nothing if none has moved.
     #[tracing::instrument]
     pub async fn save(&mut self) -> crate::Result<()> {
         self.save_to_path(Path::new(FEED_STATE_FILE)).await
@@ -117,7 +143,6 @@ impl FeedStates {
 
         debug!("Saving feed state to file");
 
-        // Save to file
         tokio::fs::write(file, serde_json::to_string_pretty(self)?).await?;
 
         self.un_dirty();
@@ -126,10 +151,14 @@ impl FeedStates {
     }
 }
 
+/// One feed's watermark.
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct FeedState {
+    /// The newest publication date selected so far. `None` until a round selects its first item.
     #[serde(with = "ts_seconds_option")]
     last_update: Option<DateTime<Utc>>,
+    /// Whether [`last_update`](Self::last_update) has moved since the last save. Never written to
+    /// the file, so a state read back from disk starts clean.
     #[serde(skip_serializing, default)]
     dirty: bool,
 }
@@ -139,11 +168,18 @@ impl FeedState {
         Self { last_update, dirty }
     }
 
+    /// Reports whether `date` is at or before the watermark, and so already posted.
+    ///
+    /// A feed holding no watermark yet answers `false` to every date.
     pub fn is_before(&self, date: &DateTime<FixedOffset>) -> bool {
         self.last_update
             .is_some_and(|last_update| *date <= last_update)
     }
 
+    /// Moves the watermark to `date` and marks the set for saving.
+    ///
+    /// The date is taken as given rather than compared, so a caller passing an older one moves the
+    /// watermark backwards and reposts everything between.
     pub fn set_last_update(&mut self, date: DateTime<Utc>) {
         self.last_update = Some(date);
         self.dirty = true;

--- a/src/feed_state.rs
+++ b/src/feed_state.rs
@@ -27,7 +27,7 @@ impl FeedStates {
             info!("Loading feed state from file");
 
             let content = std::fs::read_to_string(file)?;
-            serde_json::from_str(&content).map_err(|e| e.into())
+            serde_json::from_str(&content).map_err(Into::into)
         } else {
             // Ensure that the path exists
             let prefix = file.parent().ok_or("Invalid FEED_SATE_FILE path")?;
@@ -45,12 +45,12 @@ impl FeedStates {
         }
     }
 
-    pub fn get_feed_or_create(&mut self, feed: &Feed) -> &mut FeedState {
-        self.feeds.entry(*feed).or_default()
+    pub fn get_feed_or_create(&mut self, feed: Feed) -> &mut FeedState {
+        self.feeds.entry(feed).or_default()
     }
 
     #[tracing::instrument]
-    pub fn get_new_feed(&mut self, feed: &Feed, items: Vec<Item>) -> Vec<Item> {
+    pub fn get_new_feed(&mut self, feed: Feed, items: Vec<Item>) -> Vec<Item> {
         if items.is_empty() {
             return items;
         }
@@ -260,7 +260,7 @@ mod tests_feed_states {
 
         // Initial state
         {
-            let state = feed_states.get_feed_or_create(&feed);
+            let state = feed_states.get_feed_or_create(feed);
             assert_eq!(state, &FeedState::default());
 
             state.set_last_update(new_time);
@@ -268,7 +268,7 @@ mod tests_feed_states {
 
         // Check if state is updated
         {
-            let state = feed_states.get_feed_or_create(&feed);
+            let state = feed_states.get_feed_or_create(feed);
             assert_eq!(state.last_update, Some(new_time));
         }
     }
@@ -277,7 +277,7 @@ mod tests_feed_states {
     fn test_get_new_feed_empty() {
         let mut feed_states = create_empty_feed_states();
 
-        let items = feed_states.get_new_feed(&Feed::Netcup, Vec::new());
+        let items = feed_states.get_new_feed(Feed::Netcup, Vec::new());
         assert!(items.is_empty());
     }
 
@@ -291,7 +291,7 @@ mod tests_feed_states {
             create_rss_item(get_current_utc_time()),
             create_rss_item(highest_time),
         ];
-        let filtered_items = feed_states.get_new_feed(&feed, items.clone());
+        let filtered_items = feed_states.get_new_feed(feed, items.clone());
 
         assert_eq!(items, filtered_items);
         assert_eq!(feed_states.feeds[&feed].last_update, Some(highest_time));
@@ -311,7 +311,7 @@ mod tests_feed_states {
             items.push(create_rss_item(time));
         }
 
-        let filtered_items = feed_states.get_new_feed(&feed, items);
+        let filtered_items = feed_states.get_new_feed(feed, items);
 
         assert!(filtered_items.is_empty());
         assert!(!feed_states.is_dirty());
@@ -334,7 +334,7 @@ mod tests_feed_states {
             items.push(create_rss_item(time));
         }
 
-        let filtered_items = feed_states.get_new_feed(&feed, items.clone());
+        let filtered_items = feed_states.get_new_feed(feed, items.clone());
 
         assert!(feed_states.is_dirty());
         assert_eq!(filtered_items.len(), items.len());
@@ -351,7 +351,7 @@ mod tests_feed_states {
         let time = feed_states.feeds[&feed].last_update.unwrap();
         let items = vec![create_rss_item(time), create_rss_item(time)];
 
-        let filtered_items = feed_states.get_new_feed(&feed, items.clone());
+        let filtered_items = feed_states.get_new_feed(feed, items.clone());
 
         assert!(!feed_states.is_dirty());
         assert!(filtered_items.is_empty());
@@ -377,7 +377,7 @@ mod tests_feed_states {
         let mut items = before.clone();
         items.append(&mut after.clone());
 
-        let filtered_items = feed_states.get_new_feed(&feed, items.clone());
+        let filtered_items = feed_states.get_new_feed(feed, items.clone());
 
         assert!(feed_states.is_dirty());
         assert_eq!(filtered_items.len(), after.len());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,39 @@
+//! Watches the netcup deals RSS feed and posts new offers to a Discord webhook.
+//!
+//! The library half of the binary in `src/main.rs`. One round of work is
+//! [`FeedChecker::check_feeds`] and the process is that call on an interval, so a round can be
+//! driven from a test without a process around it.
+//!
+//! # What an item's identity is
+//!
+//! Its publication date. Each feed carries a watermark, the newest `pubDate` posted so far, and an
+//! item dated at or before it is skipped. The `guid` is never read: an offer republished under a
+//! new date is posted a second time, and an offer edited in place is not posted again.
+//!
+//! # Failure posture
+//!
+//! Nothing that happens inside a round stops the process. A feed that will not fetch and a webhook
+//! that refuses delivery are logged and counted, in `feed_fetch_errors_total` and
+//! `webhook_errors_total`. The payload netcup returns for an empty deals list and an item carrying
+//! no usable date are logged and counted nowhere. The failures that end the process are all at
+//! boot: the configuration load, the watermark file read, and the exporter binding its port.
+//!
+//! The watermark advances when an item is selected, not when it is delivered. An item whose five
+//! delivery attempts all fail is counted in `webhook_errors_total` and never tried again.
+//!
+//! # One round
+//!
+//! ```no_run
+//! # use netcup_offer_bot::{FeedChecker, config::Config};
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let config = Config::load()?;
+//! let mut checker = FeedChecker::from_config(&config);
+//! checker.check_feeds().await;
+//! # Ok(())
+//! # }
+//! ```
+
 #[macro_use]
 extern crate tracing;
 
@@ -19,8 +55,13 @@ pub mod feed;
 mod feed_state;
 mod metrics;
 
+/// The outcome of anything in this crate that can fail.
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// Everything one poll round needs, carried between rounds.
+///
+/// The watermarks live in memory here and reach disk at the end of [`check_feeds`](Self::check_feeds),
+/// so a checker dropped mid-round leaves the file holding the previous round's dates.
 #[derive(Debug)]
 pub struct FeedChecker {
     client: ClientWithMiddleware,
@@ -29,6 +70,8 @@ pub struct FeedChecker {
 }
 
 impl FeedChecker {
+    /// Builds a checker over an already-built client, watermark set and webhook.
+    #[must_use]
     pub fn new(client: ClientWithMiddleware, states: FeedStates, webhook: DiscordWebhook) -> Self {
         Self {
             client,
@@ -37,16 +80,34 @@ impl FeedChecker {
         }
     }
 
+    /// Builds a checker whose watermarks come from `./data/feed_state.json` and whose webhook
+    /// comes from the configuration.
+    ///
+    /// The file not existing is the first-run case and not a failure: the directory is created and
+    /// the checker starts with no watermark.
+    ///
+    /// # Panics
+    /// Panics if the file exists and cannot be read or holds JSON that is not a watermark set, or
+    /// if `./data` does not exist and cannot be created.
+    #[must_use]
     pub fn from_config(config: &Config) -> Self {
         let client = ClientBuilder::new(reqwest::Client::new())
             .with(TracingMiddleware::<SpanBackendWithUrl>::new())
             .build();
+        // Unwrapped deliberately. The image runs as `1001:1001`, and a volume owned by another
+        // user should fail the boot here, not start a round with no watermark and repost the
+        // whole feed.
         let states = FeedStates::load().unwrap();
         let hook = DiscordWebhook::new(config.discord.webhook_url.clone());
 
         FeedChecker::new(client, states, hook)
     }
 
+    /// Polls every feed once, then writes the watermarks back.
+    ///
+    /// Every failure a round can produce is logged and counted where it happens, except the save,
+    /// which is logged only. A round that fails to save keeps its dates in memory and tries again
+    /// at the end of the next one.
     #[tracing::instrument]
     pub async fn check_feeds(&mut self) {
         trace!("Run feed check");
@@ -60,6 +121,15 @@ impl FeedChecker {
         }
     }
 
+    /// Polls one feed and posts every item newer than its watermark, in the order the feed listed
+    /// them.
+    ///
+    /// The watermark advances past every item that was selected, so an item that then fails all
+    /// its delivery attempts is counted in `webhook_errors_total` and not seen again.
+    ///
+    /// A payload that does not begin with an `rss` tag is logged at `WARN` and left out of
+    /// `feed_fetch_errors_total`. netcup answers with one when the deals list is empty, and at
+    /// `ERROR` the tracing layer would raise a Sentry issue for it every time.
     #[tracing::instrument]
     pub async fn check_feed(&mut self, feed: Feed) {
         debug!("Checking feed {}", feed.name());
@@ -70,7 +140,6 @@ impl FeedChecker {
 
         match feed.fetch(&self.client).await {
             Ok(feed_result) => {
-                // Filter out already sent items
                 trace!("Found {} items for feed", feed_result.items.len());
                 let items = self.states.get_new_feed(feed, feed_result.items);
                 if items.is_empty() {
@@ -80,11 +149,9 @@ impl FeedChecker {
 
                 debug!("Found {} new items", items.len());
 
-                // Increase metrics
                 let counter = metrics::get_feed_counter().with_label_values(&[feed.name()]);
                 counter.inc_by(items.len() as u64);
 
-                // Send feed to discord
                 for item in items {
                     if let Err(e) = self.hook.send_discord_message(&feed, item).await {
                         error!("Error sending message for feed {}: {}", feed.name(), e);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ impl FeedChecker {
             Ok(feed_result) => {
                 // Filter out already sent items
                 trace!("Found {} items for feed", feed_result.items.len());
-                let items = self.states.get_new_feed(&feed, feed_result.items);
+                let items = self.states.get_new_feed(feed, feed_result.items);
                 if items.is_empty() {
                     debug!("No new items found");
                     return;

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,16 +69,11 @@ fn log_configuration_layers(level: tracing::Level) {
 }
 
 fn setup_sentry(dsn: Option<&SecretString>) -> Option<ClientInitGuard> {
-    // Only enable sentry if the dsn is set
-    let dsn = match dsn {
-        Some(dsn) => dsn,
-        None => {
-            info!("telemetry.sentry_dsn not set, skipping Sentry setup");
-            return None;
-        }
+    let Some(dsn) = dsn else {
+        info!("telemetry.sentry_dsn not set, skipping Sentry setup");
+        return None;
     };
 
-    // Sentry innit
     let mut options = sentry::ClientOptions::new()
         .traces_sample_rate(0.2)
         .attach_stacktrace(true);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,18 @@
+//! The process the container runs: a boot sequence, then one round per tick.
+//!
+//! Boot order is the load-bearing part. The configuration is read before the tracing subscriber
+//! exists, because the log level is one of the keys it carries, so a failure there is reported by
+//! `main`'s `Termination` and by nothing else. Everything installed after it is installed once: a
+//! changed log level or a rotated Sentry DSN reaches the process on the next restart and not
+//! before.
+//!
+//! Nothing after boot ends the process. A round logs and counts whatever it hits, and the interval
+//! stream has no end, so the `Ok(())` below is unreachable and the container exits only when it is
+//! stopped or when it panics.
+//!
+//! Ticks keep tokio's default burst behaviour: a round that runs longer than the interval is
+//! followed immediately by the next one instead of being skipped.
+
 #[macro_use]
 extern crate tracing;
 
@@ -16,16 +31,14 @@ use tracing_subscriber::{Layer, filter};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Loaded before anything is installed: every knob below, the log level included, is part of
-    // the same layered configuration, so a failure here is reported by `main`'s `Termination`
-    // rather than by a subscriber that does not exist yet.
     let config = Config::load()?;
 
     setup_tracing(config.telemetry.log_level);
 
     log_configuration_layers(config.telemetry.log_level);
 
-    // Prevents the process from exiting until all events are sent
+    // Bound for the whole of `main`: the guard flushes queued events when it drops, and a `_`
+    // binding would drop it at the end of this statement.
     let _sentry = setup_sentry(config.telemetry.sentry_dsn.as_ref());
 
     setup_metrics(&config.metrics.socket())?;
@@ -40,6 +53,11 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
+/// Installs the subscriber: stdout at `level`, Sentry at `DEBUG` and above.
+///
+/// The two filters are independent on purpose. Sentry's layer keeps collecting `DEBUG` events as
+/// breadcrumbs however quiet stdout is, so an issue raised from an `ERROR` still arrives with the
+/// round that led to it attached.
 fn setup_tracing(level: tracing::Level) {
     tracing_subscriber::registry()
         .with(tracing_subscriber::fmt::layer().with_filter(filter::LevelFilter::from_level(level)))
@@ -47,7 +65,7 @@ fn setup_tracing(level: tracing::Level) {
         .init();
 }
 
-/// Report which layer supplied each configuration key.
+/// Reports which layer supplied each configuration key.
 ///
 /// The answer to "the `Secret` is mounted and the bot is still posting to the old webhook": the
 /// mount is listed, and so is the stale environment variable sitting on top of it. The report
@@ -68,6 +86,11 @@ fn log_configuration_layers(level: tracing::Level) {
     }
 }
 
+/// Initialises Sentry, or returns `None` when no DSN is configured.
+///
+/// The guard has to outlive everything worth reporting: dropping it flushes what is queued, and
+/// that is the only flush this process performs. One transaction in five is sampled, and the
+/// release is whatever `sentry::release_name!` reads out of the build.
 fn setup_sentry(dsn: Option<&SecretString>) -> Option<ClientInitGuard> {
     let Some(dsn) = dsn else {
         info!("telemetry.sentry_dsn not set, skipping Sentry setup");
@@ -84,6 +107,11 @@ fn setup_sentry(dsn: Option<&SecretString>) -> Option<ClientInitGuard> {
     Some(sentry::init((dsn.expose_secret(), options)))
 }
 
+/// Starts the Prometheus exporter on `socket`.
+///
+/// # Errors
+/// Fails if the address is already in use or cannot be bound. `main` propagates it, so a port
+/// clash stops the boot rather than leaving the process running without metrics.
 fn setup_metrics(socket: &SocketAddr) -> Result<()> {
     prometheus_exporter::start(*socket)?;
     Ok(())

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,3 +1,11 @@
+//! The four Prometheus series this process exports, each labelled by feed.
+//!
+//! Each registers itself into the default registry the first time it is asked for, so none of the
+//! four appears in a scrape taken before the first round has run.
+//!
+//! A registration that fails is a duplicate metric name in this file, and it panics: the mistake
+//! is in the source, and the round that would have counted something is the round that finds it.
+
 use std::sync::OnceLock;
 
 use prometheus::{HistogramVec, IntCounterVec, register_histogram_vec, register_int_counter_vec};

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -89,6 +89,10 @@ fn env_overrides_every_default() {
 /// where deriving the name would test the wrong thing: `jail.config` sets
 /// `$NETCUP_OFFER_BOT_CONFIG` as well, and the default path is exactly what is under test.
 #[test]
+#[allow(
+    clippy::duration_suboptimal_units,
+    reason = "the literal mirrors check_interval_secs in the TOML above it"
+)]
 fn a_toml_file_supplies_the_whole_configuration() {
     harness().run(|jail| {
         jail.write(

--- a/tests/webhook_retry.rs
+++ b/tests/webhook_retry.rs
@@ -1,8 +1,12 @@
 //! Delivery, driven against a mock Discord.
 //!
-//! What is pinned here is the retry: a `429` carrying `retry-after` is waited out and the item is
-//! posted on the second attempt rather than dropped. The webhook client is `reqwest`'s own, so a
-//! mock server is the only way to reach the loop at all.
+//! What is pinned here is the retry loop, one branch per test: a `429` carrying `retry-after` is
+//! waited out, a `5xx` backs off and retries, a `429` that never clears gives up after
+//! `MAX_ATTEMPTS`, and any other `4xx` fails on the first response without sleeping. The webhook
+//! client is `reqwest`'s own, so a mock server is the only way to reach the loop at all.
+//!
+//! The waits are real. `retry-after: 0` keeps the rate-limit tests to the one-second buffer per
+//! attempt, and the backoff test allows a single retry because the second would sleep four seconds.
 
 use netcup_offer_bot::discord_webhook::DiscordWebhook;
 use rss::Item;
@@ -37,6 +41,110 @@ async fn test_webhook_retry_on_429() {
     let feed = netcup_offer_bot::feed::Feed::Netcup;
 
     let result = webhook.send_discord_message(&feed, item).await;
+    assert!(result.is_ok());
+    assert!(result.unwrap());
+}
+
+/// Builds the item the tests post. The webhook reads the title and the description and nothing
+/// else, so the values only have to be present.
+fn test_item() -> Item {
+    let mut item = Item::default();
+    item.set_title(Some("Test Item".to_string()));
+    item.set_description(Some("Test Description".to_string()));
+    item
+}
+
+#[tokio::test]
+async fn test_webhook_retries_server_error() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(503))
+        .up_to_n_times(1)
+        .mount(&mock_server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&mock_server)
+        .await;
+
+    let webhook = DiscordWebhook::new(SecretString::from(mock_server.uri()));
+    let result = webhook
+        .send_discord_message(&netcup_offer_bot::feed::Feed::Netcup, test_item())
+        .await;
+
+    assert!(result.is_ok());
+    assert!(result.unwrap());
+}
+
+#[tokio::test]
+async fn test_webhook_gives_up_when_rate_limit_never_clears() {
+    let mock_server = MockServer::start().await;
+
+    // Every attempt is rate limited, so the loop runs to MAX_ATTEMPTS and returns the error
+    // rather than posting. `retry-after: 0` leaves only the one-second buffer per wait.
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(429).insert_header("retry-after", "0"))
+        .mount(&mock_server)
+        .await;
+
+    let webhook = DiscordWebhook::new(SecretString::from(mock_server.uri()));
+    let result = webhook
+        .send_discord_message(&netcup_offer_bot::feed::Feed::Netcup, test_item())
+        .await;
+
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_webhook_does_not_retry_client_error() {
+    let mock_server = MockServer::start().await;
+
+    // A 404 is the webhook URL being wrong, which no number of retries fixes. It has to fail on
+    // the first response, so this test also proves the loop does not sleep on it.
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(404))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let webhook = DiscordWebhook::new(SecretString::from(mock_server.uri()));
+    let result = webhook
+        .send_discord_message(&netcup_offer_bot::feed::Feed::Netcup, test_item())
+        .await;
+
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_webhook_rate_limited_without_retry_after_header() {
+    let mock_server = MockServer::start().await;
+
+    // No `retry-after`, so the wait falls back to DEFAULT_RETRY_AFTER plus the buffer instead of
+    // retrying immediately inside the window Discord is describing.
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(429))
+        .up_to_n_times(1)
+        .mount(&mock_server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&mock_server)
+        .await;
+
+    let webhook = DiscordWebhook::new(SecretString::from(mock_server.uri()));
+    let result = webhook
+        .send_discord_message(&netcup_offer_bot::feed::Feed::Netcup, test_item())
+        .await;
+
     assert!(result.is_ok());
     assert!(result.unwrap());
 }

--- a/tests/webhook_retry.rs
+++ b/tests/webhook_retry.rs
@@ -1,3 +1,9 @@
+//! Delivery, driven against a mock Discord.
+//!
+//! What is pinned here is the retry: a `429` carrying `retry-after` is waited out and the item is
+//! posted on the second attempt rather than dropped. The webhook client is `reqwest`'s own, so a
+//! mock server is the only way to reach the loop at all.
+
 use netcup_offer_bot::discord_webhook::DiscordWebhook;
 use rss::Item;
 use secrecy::SecretString;


### PR DESCRIPTION
> **This PR is not documentation only. Read the second commit before merging.**
>
> `abf04c1 fix(webhook): keep the fraction in a retry-after wait` restructures
> `src/discord_webhook.rs` by 209 lines, turning methods into free functions and hoisting
> `MAX_ATTEMPTS`, `DEFAULT_RETRY_AFTER` and `RETRY_AFTER_BUFFER` into constants. It also touches
> `error.rs`, `feed.rs`, `feed_state.rs`, `lib.rs` and `main.rs`. That is a refactor, and the
> `fix` type undersells it. It is entangled with the documentation commit on top, which describes
> the restructured shape, so splitting it now would mean rewriting both. It needs the review a
> refactor gets, not the review a docs PR gets.

## The documentation

Every exported item says what it does and then only what its signature cannot.

The two crate roots carry the design record. The library root states that an item's identity is its
publication date, and that the watermark advances when an item is selected rather than when it is
delivered, so an item whose five attempts all fail is counted and never seen again. The binary root
states the boot order and that nothing after it ends the process.

Newly documented: `FeedChecker` and its two rounds, `Feed` and its fetch, `DiscordWebhook` and the
retry policy, the watermark file and what it does at an equal date, the four Prometheus series, and
the error type. Private items are documented only where the reason is not visible at the definition,
which is why the metric accessors carry nothing.

Three markers, three readers. The rustdoc on a config field is rendered into the README table and
into `docs/config.contract.json` for an operator, so it says what the value is and what holding it
costs. Why the field is `skip_serializing`, and why `Config` carries two derives it never
deserialises through, are plain `//` comments underneath, which nothing renders.
`FeedStates::load().unwrap()` gained one too: the image runs as 1001:1001, and a volume owned by
another user should fail the boot rather than start a round with no watermark.

## The gate

`[workspace.lints.rust]` turns on `missing_docs`, `[workspace.lints.clippy]` takes `pedantic` plus
the documentation lints, and the `doc` job runs rustdoc with `-D warnings` so the rustdoc-only lints
fail a pull request instead of scrolling past in a local build.

## Verification

`cargo doc --all-features --no-deps` with `RUSTDOCFLAGS=-D warnings`: clean.
`cargo test --all-features`: 48 tests passing across six binaries.
`cargo llvm-cov --all-features`: 73.56%, up from master's 72.19%.

## Coverage

The refactor moved the retry loop without adding tests for the branches it introduced, and codecov
counts relocated lines as new, so patch coverage read 64.5% on a diff whose real delta is +3 lines.
Four branches had no test at all and now do: a `5xx` backing off then succeeding, a `429` that never
clears giving up at `MAX_ATTEMPTS`, a `4xx` failing without sleeping, and a `429` with no
`retry-after` falling back to the default wait. `src/discord_webhook.rs` goes 63.46% to 76.92%.
`cargo clippy --all-features --all-targets`: no warnings.

Standard: [docs/doc-comments](https://github.com/TimSchoenle/actions/tree/main/docs/doc-comments).

