### PR TITLE
feat!: make Sentry an optional feature configured through telemetry.sentry

### DIFF
--- a/.github/templates/CONFIGURATION.md.hbs
+++ b/.github/templates/CONFIGURATION.md.hbs
@@ -66,6 +66,55 @@ For a single secret, Docker's own convention reaches the same place:
 -e {{ prefix }}DISCORD{{ nesting_separator }}WEBHOOK_URL{{ indirection_suffix }}="/run/secrets/webhook"
 ```
 
+## `telemetry.sentry`
+
+Off unless a deployment switches it on, and the whole block is inert until it does. A DSN is an
+egress destination for whatever a log line happens to carry, so turning it on is a decision made
+once per deployment rather than one this image makes by shipping a key.
+
+```bash
+docker run --rm \
+  -e {{ prefix }}DISCORD{{ nesting_separator }}WEBHOOK_URL{{ indirection_suffix }}="/run/secrets/webhook" \
+  -e {{ prefix }}FEED{{ nesting_separator }}CHECK_INTERVAL_SECS=900 \
+  -e {{ prefix }}TELEMETRY{{ nesting_separator }}SENTRY{{ nesting_separator }}ENABLED=true \
+  -e {{ prefix }}TELEMETRY{{ nesting_separator }}SENTRY{{ nesting_separator }}DSN{{ indirection_suffix }}="/run/secrets/sentry-dsn" \
+  -e {{ prefix }}TELEMETRY{{ nesting_separator }}SENTRY{{ nesting_separator }}TRACES_SAMPLE_RATE=0.1 \
+  -v netcup-offer-bot-data:/app/data \
+  {{ image }}:{{ release.tag }}
+```
+
+Four things about it are worth knowing before it is switched on:
+
+- **`ENABLED=true` without a usable DSN fails the boot.** So does a DSN that does not parse, and
+  so does a sample rate outside `0.0`–`1.0`. A reporter that reports nowhere is the one failure
+  nobody sees: the process boots, serves, and a quiet issue stream looks exactly like a quiet
+  week. An empty value counts as no DSN, because an unfilled chart value and a compose
+  pass-through both resolve to one.
+- **The DSN is a credential** for the project's ingest endpoint, and takes the same three
+  spellings the webhook does. Mount it.
+- **Tracing is a second switch.** `traces_sample_rate` is `0.0` by default, and at `0.0` no spans
+  are built at all — errors are still reported. `0.05`–`0.2` is an ordinary production figure.
+- **The Sentry thresholds do not follow `telemetry.log_level`.** `capture_level` decides what
+  becomes an issue and `breadcrumb_level` what is kept as the trail attached to the next one, and
+  the layer goes on collecting that trail however quiet stdout has been told to be. Setting
+  `log_level = "ERROR"` does not empty the breadcrumbs on an issue.
+
+### The key this replaced
+
+`{{ prefix }}TELEMETRY{{ nesting_separator }}SENTRY_DSN` is gone. Supplying it fails the boot
+naming `telemetry.sentry.dsn`, rather than being ignored: a rename that resolved silently would
+take a deployment's error reporting away in the upgrade that renamed the key, and a DSN alone no
+longer switches Sentry on — `telemetry.sentry.enabled` does.
+
+### Builds without Sentry
+
+The client, the panic hook and the `tracing` layer are behind the crate's default `sentry`
+feature. `cargo build --release --no-default-features` produces a binary with no Sentry code in
+it and no egress path to a third party; the keys above are still read, documented and published
+in the contract, so one document describes every build. Such a binary refuses to boot on
+`telemetry.sentry.enabled` instead of starting a reporter it has no client for. The published
+image is built with default features and reports.
+
 ## The config contract
 
 Every release publishes the key table as a machine-readable document, so a chart deploying an

--- a/.github/templates/README.md.hbs
+++ b/.github/templates/README.md.hbs
@@ -81,8 +81,11 @@ every restart reposts whatever the feed still lists.
   as a fetch error, because the upstream answers with an HTML page often enough that alerting on
   it would be alerting on netcup's bad minute.
 - Four Prometheus metrics, on an exporter that binds `127.0.0.1:9184` by default.
-- Errors reach Sentry when a DSN is configured. The image build uploads debug symbols before it
-  strips the binary, so a musl release build still symbolicates.
+- Errors reach Sentry when `telemetry.sentry.enabled` is set, with performance tracing under
+  `telemetry.sentry.traces_sample_rate` and the issue and breadcrumb thresholds as keys of their
+  own. Switched on without a usable DSN it fails the boot rather than running as a reporter that
+  reports nowhere. The image build uploads debug symbols before it strips the binary, so a musl
+  release build still symbolicates.
 
 ## Installation
 
@@ -114,6 +117,11 @@ git clone https://github.com/{{ repo.slug }}.git
 cd {{ repo.name }}
 cargo build --release
 ```
+
+`--no-default-features` drops the `sentry` feature, and with it the client, the panic hook and
+the `tracing` layer — a binary with no error-reporting path out of the process at all. It reads
+the same `telemetry.sentry` keys and refuses to boot on `telemetry.sentry.enabled`, rather than
+starting as a reporter it has no client for.
 
 ## Usage
 
@@ -185,6 +193,19 @@ container.
 | `feed_fetch_duration_seconds` | histogram | `feed` | Seconds one fetch of the feed took |
 | `feed_fetch_errors_total` | counter | `feed` | Fetches that failed, malformed payloads excluded |
 | `webhook_errors_total` | counter | `feed` | Items still undelivered after the fifth attempt |
+
+### Error reporting and tracing
+
+Off unless `telemetry.sentry.enabled` is set. On, the process reports issues at
+`telemetry.sentry.capture_level`, attaches the records above `telemetry.sentry.breadcrumb_level`
+as the trail behind each one, and records the fraction of traces
+`telemetry.sentry.traces_sample_rate` names — `0.0`, none, by default. Both thresholds are
+independent of `telemetry.log_level`, so an issue raised from an `ERROR` still arrives with the
+round that led to it attached however quiet stdout is.
+
+Switched on without a usable DSN, an unparseable DSN or a rate outside `0.0`–`1.0` fails the
+boot. [docs/CONFIGURATION.md](docs/CONFIGURATION.md#telemetrysentry) has the rest, including the
+key this replaced and what a `--no-default-features` build does instead.
 
 ### State
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -141,6 +141,36 @@ jobs:
       - name: Doctests
         run: cargo test --doc --all-features
 
+  # The half of the crate `--all-features` never builds. `sentry` is a default feature, so every
+  # other job here compiles the arm of `src/telemetry/sentry.rs` that has a client and none of
+  # them compile the arm that does not. Without this, the build with no egress path to a third
+  # party would break in a pull request that never mentions Sentry and stay broken until someone
+  # tried to produce one.
+  no-default-features:
+    name: No Default Features
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to checkout the code
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Install stable toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+
+      - name: Clippy
+        run: cargo clippy --no-default-features --all-targets -- -D warnings
+
+      - name: Test
+        run: cargo test --no-default-features
+
   # The reverse gate on the config contract: regenerate the committed document and the
   # Dockerfile's `LABEL` block from the Rust types and fail if either has drifted. A renamed key
   # or a renamed prefix then shows up in the pull request that renamed it, as a diff a reviewer

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,24 @@ path = "src/lib.rs"
 path = "src/main.rs"
 name = "netcup-offer-bot"
 
-# The two generators, and nothing else. `terrace-config/schema` links `serde_json` and compiles
-# a derive macro over every config struct, which is weight an image that will never print a table
-# has no reason to carry — so the container's runtime stage builds with default features, and the
-# feature is turned on only by the documentation job and by the builder stage that writes the
-# config contract.
+# `sentry` is default and `config-schema` is not, for opposite reasons.
+#
+# `terrace-config/schema` links `serde_json` and compiles a derive macro over every config
+# struct, which is weight an image that will never print a table has no reason to carry — so the
+# container's runtime stage builds with default features, and the feature is turned on only by
+# the documentation job and by the builder stage that writes the config contract.
+#
+# `sentry` is the client, the panic hook and the `tracing` layer that the `telemetry.sentry`
+# block configures. It is default because the published image reports, and a release that
+# quietly stopped doing so would be noticed by the absence of issues rather than by a failure.
+# `--no-default-features` links no Sentry code at all — for a build that must carry no egress
+# path to a third party — and the *configuration surface does not move with it*: the keys are
+# described, documented and published in the contract either way, so one document describes
+# every build of this crate. What such a build does instead is refuse to boot on
+# `telemetry.sentry.enabled` rather than start a reporter that reports nowhere.
 [features]
+default = ["sentry"]
+sentry = ["dep:sentry"]
 config-schema = ["terrace-config/schema-cli"]
 
 # Declared so `cargo clippy --all-targets --features config-schema` keeps the generators
@@ -44,7 +56,13 @@ required-features = ["config-schema"]
 anyhow = { version = "1.0.100", features = ["backtrace"] }
 thiserror = "2.0.18"
 backtrace = "0.3.76"
-sentry = { version = "0.49.1", default-features = false, features = ["anyhow", "debug-images", "reqwest", "rustls", "backtrace", "tracing"] }
+# Optional, behind the `sentry` feature above; the feature list is unchanged from when this was
+# a hard dependency. `default-features = false` keeps the transport on the `reqwest`/`rustls`
+# stack this crate already links rather than pulling in a second HTTP client and a second TLS
+# implementation. `tracing` is the layer `src/telemetry/sentry.rs` installs, and `backtrace` and
+# `debug-images` are what let a stripped musl release build symbolicate against the debug files
+# the image build uploads — see the `[profile.release]` note on `debug = "limited"` below.
+sentry = { version = "0.49.1", optional = true, default-features = false, features = ["anyhow", "debug-images", "reqwest", "rustls", "backtrace", "tracing"] }
 chrono = { version = "0.4.43", default-features = false, features = ["clock", "std", "wasmbind", "serde"] }
 rss = { version = "2.0.12", features = ["validation"] }
 reqwest = { version = "0.13.1", default-features = false, features = ["json", "rustls", "stream", "gzip"] }

--- a/README.md
+++ b/README.md
@@ -81,8 +81,11 @@ every restart reposts whatever the feed still lists.
   as a fetch error, because the upstream answers with an HTML page often enough that alerting on
   it would be alerting on netcup's bad minute.
 - Four Prometheus metrics, on an exporter that binds `127.0.0.1:9184` by default.
-- Errors reach Sentry when a DSN is configured. The image build uploads debug symbols before it
-  strips the binary, so a musl release build still symbolicates.
+- Errors reach Sentry when `telemetry.sentry.enabled` is set, with performance tracing under
+  `telemetry.sentry.traces_sample_rate` and the issue and breadcrumb thresholds as keys of their
+  own. Switched on without a usable DSN it fails the boot rather than running as a reporter that
+  reports nowhere. The image build uploads debug symbols before it strips the binary, so a musl
+  release build still symbolicates.
 
 ## Installation
 
@@ -114,6 +117,11 @@ git clone https://github.com/TimSchoenle/netcup-offer-bot.git
 cd netcup-offer-bot
 cargo build --release
 ```
+
+`--no-default-features` drops the `sentry` feature, and with it the client, the panic hook and
+the `tracing` layer — a binary with no error-reporting path out of the process at all. It reads
+the same `telemetry.sentry` keys and refuses to boot on `telemetry.sentry.enabled`, rather than
+starting as a reporter it has no client for.
 
 ## Usage
 
@@ -168,7 +176,19 @@ Nesting is `__`, because a single underscore is part of a field name. Case is fo
 | `metrics.ip` | `IpAddr` | `NETCUP_OFFER_BOT_METRICS__IP` | `127.0.0.1` | — | Address the Prometheus exporter binds. `0.0.0.0` to reach it from outside the container. |
 | `metrics.port` | `u16` | `NETCUP_OFFER_BOT_METRICS__PORT` | `9184` | — | Port the Prometheus exporter listens on. |
 | `telemetry.log_level` | `Level` | `NETCUP_OFFER_BOT_TELEMETRY__LOG_LEVEL` | `INFO` | — | The maximum verbosity that reaches stdout: `TRACE`, `DEBUG`, `INFO`, `WARN` or `ERROR`, in any case. |
-| `telemetry.sentry_dsn` | `SecretString` | `NETCUP_OFFER_BOT_TELEMETRY__SENTRY_DSN` | unset | secret | Sentry DSN. Unset disables Sentry entirely. |
+| `telemetry.sentry.enabled` | `bool` | `NETCUP_OFFER_BOT_TELEMETRY__SENTRY__ENABLED` | `false` | — | Initialise the Sentry client. `false` installs no client, no panic hook and no layer, so every other key here is inert and nothing leaves the process. |
+| `telemetry.sentry.dsn` | `SecretString` | `NETCUP_OFFER_BOT_TELEMETRY__SENTRY__DSN` | unset | secret | Ingest URL, `https://<key>@<host>/<project>`. Required once `enabled` is set. |
+| `telemetry.sentry.environment` | `String` | `NETCUP_OFFER_BOT_TELEMETRY__SENTRY__ENVIRONMENT` | unset | — | Environment tag on every event. Defaults to `production`, or `development` for a debug build. |
+| `telemetry.sentry.release` | `String` | `NETCUP_OFFER_BOT_TELEMETRY__SENTRY__RELEASE` | unset | — | Release tag on every event. Defaults to the version the binary was built from. |
+| `telemetry.sentry.server_name` | `String` | `NETCUP_OFFER_BOT_TELEMETRY__SENTRY__SERVER_NAME` | unset | — | Host tag on every event. Unset, Sentry reports none. |
+| `telemetry.sentry.sample_rate` | `f32` | `NETCUP_OFFER_BOT_TELEMETRY__SENTRY__SAMPLE_RATE` | `1` | — | Fraction of captured events actually sent, `0.0`–`1.0`. |
+| `telemetry.sentry.traces_sample_rate` | `f32` | `NETCUP_OFFER_BOT_TELEMETRY__SENTRY__TRACES_SAMPLE_RATE` | `0` | — | Fraction of traces that are recorded, `0.0`–`1.0`. `0.0` records none. |
+| `telemetry.sentry.capture_level` | `SentryLevel`: `off` \| `error` \| `warn` \| `info` \| `debug` \| `trace` | `NETCUP_OFFER_BOT_TELEMETRY__SENTRY__CAPTURE_LEVEL` | `error` | — | Least severe `tracing` level reported as a Sentry issue: `off`, `error`, `warn`, `info`, `debug` or `trace`. |
+| `telemetry.sentry.breadcrumb_level` | `SentryLevel`: `off` \| `error` \| `warn` \| `info` \| `debug` \| `trace` | `NETCUP_OFFER_BOT_TELEMETRY__SENTRY__BREADCRUMB_LEVEL` | `info` | — | Least severe `tracing` level kept as a breadcrumb — the trail attached to the next issue. |
+| `telemetry.sentry.max_breadcrumbs` | `usize` | `NETCUP_OFFER_BOT_TELEMETRY__SENTRY__MAX_BREADCRUMBS` | `100` | — | How many breadcrumbs one event carries. |
+| `telemetry.sentry.attach_stacktraces` | `bool` | `NETCUP_OFFER_BOT_TELEMETRY__SENTRY__ATTACH_STACKTRACES` | `true` | — | Attach a stack trace to events that carry none of their own. |
+| `telemetry.sentry.shutdown_timeout_secs` | `u64` | `NETCUP_OFFER_BOT_TELEMETRY__SENTRY__SHUTDOWN_TIMEOUT_SECS` | `2` | — | How long process exit waits for queued events to drain. |
+| `telemetry.sentry.debug` | `bool` | `NETCUP_OFFER_BOT_TELEMETRY__SENTRY__DEBUG` | `false` | — | Print the SDK's own diagnostics to stderr. For proving a DSN works, not for running. |
 
 Run with `NETCUP_OFFER_BOT_TELEMETRY__LOG_LEVEL=DEBUG` and the boot log names the layer every
 key was read from. That is what answers "the `Secret` is mounted and the bot is still posting to
@@ -192,6 +212,19 @@ container.
 | `feed_fetch_duration_seconds` | histogram | `feed` | Seconds one fetch of the feed took |
 | `feed_fetch_errors_total` | counter | `feed` | Fetches that failed, malformed payloads excluded |
 | `webhook_errors_total` | counter | `feed` | Items still undelivered after the fifth attempt |
+
+### Error reporting and tracing
+
+Off unless `telemetry.sentry.enabled` is set. On, the process reports issues at
+`telemetry.sentry.capture_level`, attaches the records above `telemetry.sentry.breadcrumb_level`
+as the trail behind each one, and records the fraction of traces
+`telemetry.sentry.traces_sample_rate` names — `0.0`, none, by default. Both thresholds are
+independent of `telemetry.log_level`, so an issue raised from an `ERROR` still arrives with the
+round that led to it attached however quiet stdout is.
+
+Switched on without a usable DSN, an unparseable DSN or a rate outside `0.0`–`1.0` fails the
+boot. [docs/CONFIGURATION.md](docs/CONFIGURATION.md#telemetrysentry) has the rest, including the
+key this replaced and what a `--no-default-features` build does instead.
 
 ### State
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -73,10 +73,62 @@ check_interval_secs = 0
 # Type: Level
 # log_level = "INFO"
 
-# Sentry DSN. Unset disables Sentry entirely.
+[telemetry.sentry]
+# Initialise the Sentry client. `false` installs no client, no panic hook and no layer, so every other key here is inert and nothing leaves the process.
+# Type: bool
+# enabled = false
+
+# Ingest URL, `https://<key>@<host>/<project>`. Required once `enabled` is set.
 # Type: SecretString
 # Secret: the value below is a placeholder.
-# sentry_dsn = "<secret>"
+# dsn = "<secret>"
+
+# Environment tag on every event. Defaults to `production`, or `development` for a debug build.
+# Type: String
+# Unset by default: the value below is only the shape.
+# environment = "<value>"
+
+# Release tag on every event. Defaults to the version the binary was built from.
+# Type: String
+# Unset by default: the value below is only the shape.
+# release = "<value>"
+
+# Host tag on every event. Unset, Sentry reports none.
+# Type: String
+# Unset by default: the value below is only the shape.
+# server_name = "<value>"
+
+# Fraction of captured events actually sent, `0.0`–`1.0`.
+# Type: f32
+# sample_rate = 1.0
+
+# Fraction of traces that are recorded, `0.0`–`1.0`. `0.0` records none.
+# Type: f32
+# traces_sample_rate = 0.0
+
+# Least severe `tracing` level reported as a Sentry issue: `off`, `error`, `warn`, `info`, `debug` or `trace`.
+# Type: SentryLevel — one of: off, error, warn, info, debug, trace
+# capture_level = "error"
+
+# Least severe `tracing` level kept as a breadcrumb — the trail attached to the next issue.
+# Type: SentryLevel — one of: off, error, warn, info, debug, trace
+# breadcrumb_level = "info"
+
+# How many breadcrumbs one event carries.
+# Type: usize
+# max_breadcrumbs = 100
+
+# Attach a stack trace to events that carry none of their own.
+# Type: bool
+# attach_stacktraces = true
+
+# How long process exit waits for queued events to drain.
+# Type: u64
+# shutdown_timeout_secs = 2
+
+# Print the SDK's own diagnostics to stderr. For proving a DSN works, not for running.
+# Type: bool
+# debug = false
 ```
 
 ## Secrets from files
@@ -98,6 +150,55 @@ For a single secret, Docker's own convention reaches the same place:
 ```bash
 -e NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL_FILE="/run/secrets/webhook"
 ```
+
+## `telemetry.sentry`
+
+Off unless a deployment switches it on, and the whole block is inert until it does. A DSN is an
+egress destination for whatever a log line happens to carry, so turning it on is a decision made
+once per deployment rather than one this image makes by shipping a key.
+
+```bash
+docker run --rm \
+  -e NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL_FILE="/run/secrets/webhook" \
+  -e NETCUP_OFFER_BOT_FEED__CHECK_INTERVAL_SECS=900 \
+  -e NETCUP_OFFER_BOT_TELEMETRY__SENTRY__ENABLED=true \
+  -e NETCUP_OFFER_BOT_TELEMETRY__SENTRY__DSN_FILE="/run/secrets/sentry-dsn" \
+  -e NETCUP_OFFER_BOT_TELEMETRY__SENTRY__TRACES_SAMPLE_RATE=0.1 \
+  -v netcup-offer-bot-data:/app/data \
+  timmi6790/netcup-offer-bot:v2.1.1
+```
+
+Four things about it are worth knowing before it is switched on:
+
+- **`ENABLED=true` without a usable DSN fails the boot.** So does a DSN that does not parse, and
+  so does a sample rate outside `0.0`–`1.0`. A reporter that reports nowhere is the one failure
+  nobody sees: the process boots, serves, and a quiet issue stream looks exactly like a quiet
+  week. An empty value counts as no DSN, because an unfilled chart value and a compose
+  pass-through both resolve to one.
+- **The DSN is a credential** for the project's ingest endpoint, and takes the same three
+  spellings the webhook does. Mount it.
+- **Tracing is a second switch.** `traces_sample_rate` is `0.0` by default, and at `0.0` no spans
+  are built at all — errors are still reported. `0.05`–`0.2` is an ordinary production figure.
+- **The Sentry thresholds do not follow `telemetry.log_level`.** `capture_level` decides what
+  becomes an issue and `breadcrumb_level` what is kept as the trail attached to the next one, and
+  the layer goes on collecting that trail however quiet stdout has been told to be. Setting
+  `log_level = "ERROR"` does not empty the breadcrumbs on an issue.
+
+### The key this replaced
+
+`NETCUP_OFFER_BOT_TELEMETRY__SENTRY_DSN` is gone. Supplying it fails the boot
+naming `telemetry.sentry.dsn`, rather than being ignored: a rename that resolved silently would
+take a deployment's error reporting away in the upgrade that renamed the key, and a DSN alone no
+longer switches Sentry on — `telemetry.sentry.enabled` does.
+
+### Builds without Sentry
+
+The client, the panic hook and the `tracing` layer are behind the crate's default `sentry`
+feature. `cargo build --release --no-default-features` produces a binary with no Sentry code in
+it and no egress path to a third party; the keys above are still read, documented and published
+in the contract, so one document describes every build. Such a binary refuses to boot on
+`telemetry.sentry.enabled` instead of starting a reporter it has no client for. The published
+image is built with default features and reports.
 
 ## The config contract
 

--- a/docs/config.contract.json
+++ b/docs/config.contract.json
@@ -150,11 +150,38 @@
         "reserved": false
       },
       {
-        "path": "telemetry.sentry_dsn",
-        "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY_DSN",
-        "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY_DSN_FILE",
-        "secrets_file": "telemetry__sentry_dsn",
-        "docs": "Sentry DSN. Unset disables Sentry entirely.\n\nA write credential for the project's event stream, wrapped for the reason\n[`DiscordConfig::webhook_url`] is.",
+        "path": "telemetry.sentry.enabled",
+        "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__ENABLED",
+        "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__ENABLED_FILE",
+        "secrets_file": "telemetry__sentry__enabled",
+        "docs": "Initialise the Sentry client. `false` installs no client, no panic hook and no layer, so\nevery other key here is inert and nothing leaves the process.\n\nSet on a binary built with `--no-default-features` it fails the boot: that build carries\nno client to install, and starting anyway would be the silent no-op this key exists to\navoid.",
+        "ty": "bool",
+        "values": [],
+        "constraint": {
+          "type": "boolean"
+        },
+        "text_constraint": {
+          "pattern": "^\\s*(true|false)\\s*$",
+          "type": "string"
+        },
+        "text_form": "boolean",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": "false",
+        "default_value": false,
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "telemetry.sentry.dsn",
+        "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__DSN",
+        "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__DSN_FILE",
+        "secrets_file": "telemetry__sentry__dsn",
+        "docs": "Ingest URL, `https://<key>@<host>/<project>`. Required once `enabled` is set.\n\nA write credential for the project's event stream, wrapped for the reason\n[`DiscordConfig::webhook_url`](super::DiscordConfig::webhook_url) is. Empty is treated as\nabsent rather than as a malformed URL, because an unfilled chart value and a compose\npass-through both produce an empty string and neither is a typo in a DSN.",
         "ty": "SecretString",
         "values": [],
         "constraint": {
@@ -170,6 +197,315 @@
         "note": null,
         "required": false,
         "secret": true,
+        "reserved": false
+      },
+      {
+        "path": "telemetry.sentry.environment",
+        "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__ENVIRONMENT",
+        "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__ENVIRONMENT_FILE",
+        "secrets_file": "telemetry__sentry__environment",
+        "docs": "Environment tag on every event. Defaults to `production`, or `development` for a debug\nbuild.\n\nAlways sent, never left for the SDK to fill in. `sentry::init` otherwise reads\n`SENTRY_ENVIRONMENT` from the process environment — a second configuration channel that\nbypasses the layered loader, its shadow-key rejection and the contract, whose external\nsurface says this image reads nothing outside the loader's namespace.",
+        "ty": "String",
+        "values": [],
+        "constraint": {
+          "type": "string"
+        },
+        "text_form": "text",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": null,
+        "default_value": null,
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "telemetry.sentry.release",
+        "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__RELEASE",
+        "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__RELEASE_FILE",
+        "secrets_file": "telemetry__sentry__release",
+        "docs": "Release tag on every event. Defaults to the version the binary was built from.\n\nSet explicitly for the same reason [`Self::environment`] is, and this is the field that\nmakes a regression attributable to a deploy. The default is what\n`sentry::release_name!` reads out of the build, which is what the image's debug-file\nupload names the symbols under.",
+        "ty": "String",
+        "values": [],
+        "constraint": {
+          "type": "string"
+        },
+        "text_form": "text",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": null,
+        "default_value": null,
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "telemetry.sentry.server_name",
+        "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__SERVER_NAME",
+        "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__SERVER_NAME_FILE",
+        "secrets_file": "telemetry__sentry__server_name",
+        "docs": "Host tag on every event. Unset, Sentry reports none.\n\nThe hostname of a replica is infrastructure detail, and a pod's is a generated string\nthat changes on every restart, so it is worth a tag only where a deployment has a\nstable name to give it.",
+        "ty": "String",
+        "values": [],
+        "constraint": {
+          "type": "string"
+        },
+        "text_form": "text",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": null,
+        "default_value": null,
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "telemetry.sentry.sample_rate",
+        "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__SAMPLE_RATE",
+        "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__SAMPLE_RATE_FILE",
+        "secrets_file": "telemetry__sentry__sample_rate",
+        "docs": "Fraction of captured events actually sent, `0.0`–`1.0`.\n\nA blunt volume cap: it drops whole issues rather than repetitions of one, so leave it at\n`1.0` unless a quota forces otherwise.",
+        "ty": "f32",
+        "values": [],
+        "constraint": {
+          "type": "number"
+        },
+        "text_form": "unknown",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": "1",
+        "default_value": 1.0,
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "telemetry.sentry.traces_sample_rate",
+        "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__TRACES_SAMPLE_RATE",
+        "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__TRACES_SAMPLE_RATE_FILE",
+        "secrets_file": "telemetry__sentry__traces_sample_rate",
+        "docs": "Fraction of traces that are recorded, `0.0`–`1.0`. `0.0` records none.\n\nThis process starts every trace it has — nothing hands it one — so at `0.0` no spans are\nbuilt at all rather than built and dropped by the sampler. `0.05`–`0.2` is an ordinary\nproduction figure; the previous hard-coded value was `0.2`.",
+        "ty": "f32",
+        "values": [],
+        "constraint": {
+          "type": "number"
+        },
+        "text_form": "unknown",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": "0",
+        "default_value": 0.0,
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "telemetry.sentry.capture_level",
+        "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__CAPTURE_LEVEL",
+        "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__CAPTURE_LEVEL_FILE",
+        "secrets_file": "telemetry__sentry__capture_level",
+        "docs": "Least severe `tracing` level reported as a Sentry issue: `off`, `error`, `warn`, `info`,\n`debug` or `trace`.",
+        "ty": "SentryLevel",
+        "values": [
+          "off",
+          "error",
+          "warn",
+          "info",
+          "debug",
+          "trace"
+        ],
+        "constraint": {
+          "enum": [
+            "off",
+            "error",
+            "warn",
+            "info",
+            "debug",
+            "trace"
+          ],
+          "type": "string"
+        },
+        "text_constraint": {
+          "pattern": "^\\s*(off|error|warn|info|debug|trace)\\s*$",
+          "type": "string"
+        },
+        "text_form": "choice",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": "error",
+        "default_value": "error",
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "telemetry.sentry.breadcrumb_level",
+        "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__BREADCRUMB_LEVEL",
+        "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__BREADCRUMB_LEVEL_FILE",
+        "secrets_file": "telemetry__sentry__breadcrumb_level",
+        "docs": "Least severe `tracing` level kept as a breadcrumb — the trail attached to the next issue.\n\nRecords at or above [`Self::capture_level`] become issues instead. Independent of\n[`log_level`](super::TelemetryConfig::log_level) on purpose: the layer keeps collecting\nthe trail however quiet stdout is, so an issue raised from an `ERROR` still arrives with\nthe round that led to it attached.",
+        "ty": "SentryLevel",
+        "values": [
+          "off",
+          "error",
+          "warn",
+          "info",
+          "debug",
+          "trace"
+        ],
+        "constraint": {
+          "enum": [
+            "off",
+            "error",
+            "warn",
+            "info",
+            "debug",
+            "trace"
+          ],
+          "type": "string"
+        },
+        "text_constraint": {
+          "pattern": "^\\s*(off|error|warn|info|debug|trace)\\s*$",
+          "type": "string"
+        },
+        "text_form": "choice",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": "info",
+        "default_value": "info",
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "telemetry.sentry.max_breadcrumbs",
+        "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__MAX_BREADCRUMBS",
+        "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__MAX_BREADCRUMBS_FILE",
+        "secrets_file": "telemetry__sentry__max_breadcrumbs",
+        "docs": "How many breadcrumbs one event carries.",
+        "ty": "usize",
+        "values": [],
+        "constraint": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "text_constraint": {
+          "pattern": "^\\s*\\+?[0-9]+\\s*$",
+          "type": "string"
+        },
+        "text_form": "integer",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": "100",
+        "default_value": 100,
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "telemetry.sentry.attach_stacktraces",
+        "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__ATTACH_STACKTRACES",
+        "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__ATTACH_STACKTRACES_FILE",
+        "secrets_file": "telemetry__sentry__attach_stacktraces",
+        "docs": "Attach a stack trace to events that carry none of their own.",
+        "ty": "bool",
+        "values": [],
+        "constraint": {
+          "type": "boolean"
+        },
+        "text_constraint": {
+          "pattern": "^\\s*(true|false)\\s*$",
+          "type": "string"
+        },
+        "text_form": "boolean",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": "true",
+        "default_value": true,
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "telemetry.sentry.shutdown_timeout_secs",
+        "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__SHUTDOWN_TIMEOUT_SECS",
+        "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__SHUTDOWN_TIMEOUT_SECS_FILE",
+        "secrets_file": "telemetry__sentry__shutdown_timeout_secs",
+        "docs": "How long process exit waits for queued events to drain.\n\nThe only flush this process performs, and it happens when the guard `main` holds is\ndropped. A container stopped with a short grace period loses whatever is still queued\npast this window.",
+        "ty": "u64",
+        "values": [],
+        "constraint": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "text_constraint": {
+          "pattern": "^\\s*\\+?[0-9]+\\s*$",
+          "type": "string"
+        },
+        "text_form": "integer",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": "2",
+        "default_value": 2,
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "telemetry.sentry.debug",
+        "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__DEBUG",
+        "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__DEBUG_FILE",
+        "secrets_file": "telemetry__sentry__debug",
+        "docs": "Print the SDK's own diagnostics to stderr. For proving a DSN works, not for running.",
+        "ty": "bool",
+        "values": [],
+        "constraint": {
+          "type": "boolean"
+        },
+        "text_constraint": {
+          "pattern": "^\\s*(true|false)\\s*$",
+          "type": "string"
+        },
+        "text_form": "boolean",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": "false",
+        "default_value": false,
+        "note": null,
+        "required": false,
+        "secret": false,
         "reserved": false
       }
     ]
@@ -225,10 +561,91 @@
             "default": "INFO",
             "description": "The maximum verbosity that reaches stdout: `TRACE`, `DEBUG`, `INFO`, `WARN` or `ERROR`,\nin any case.\n\nParsed at boot so an unusable value fails the load rather than the first log line.\n`DEBUG` and `TRACE` additionally print which layer supplied each configuration key."
           },
-          "sentry_dsn": {
-            "description": "Sentry DSN. Unset disables Sentry entirely.\n\nA write credential for the project's event stream, wrapped for the reason\n[`DiscordConfig::webhook_url`] is.",
-            "type": "string",
-            "writeOnly": true
+          "sentry": {
+            "additionalProperties": false,
+            "properties": {
+              "attach_stacktraces": {
+                "default": true,
+                "description": "Attach a stack trace to events that carry none of their own.",
+                "type": "boolean"
+              },
+              "breadcrumb_level": {
+                "default": "info",
+                "description": "Least severe `tracing` level kept as a breadcrumb — the trail attached to the next issue.\n\nRecords at or above [`Self::capture_level`] become issues instead. Independent of\n[`log_level`](super::TelemetryConfig::log_level) on purpose: the layer keeps collecting\nthe trail however quiet stdout is, so an issue raised from an `ERROR` still arrives with\nthe round that led to it attached.",
+                "enum": [
+                  "off",
+                  "error",
+                  "warn",
+                  "info",
+                  "debug",
+                  "trace"
+                ],
+                "type": "string"
+              },
+              "capture_level": {
+                "default": "error",
+                "description": "Least severe `tracing` level reported as a Sentry issue: `off`, `error`, `warn`, `info`,\n`debug` or `trace`.",
+                "enum": [
+                  "off",
+                  "error",
+                  "warn",
+                  "info",
+                  "debug",
+                  "trace"
+                ],
+                "type": "string"
+              },
+              "debug": {
+                "default": false,
+                "description": "Print the SDK's own diagnostics to stderr. For proving a DSN works, not for running.",
+                "type": "boolean"
+              },
+              "dsn": {
+                "description": "Ingest URL, `https://<key>@<host>/<project>`. Required once `enabled` is set.\n\nA write credential for the project's event stream, wrapped for the reason\n[`DiscordConfig::webhook_url`](super::DiscordConfig::webhook_url) is. Empty is treated as\nabsent rather than as a malformed URL, because an unfilled chart value and a compose\npass-through both produce an empty string and neither is a typo in a DSN.",
+                "type": "string",
+                "writeOnly": true
+              },
+              "enabled": {
+                "default": false,
+                "description": "Initialise the Sentry client. `false` installs no client, no panic hook and no layer, so\nevery other key here is inert and nothing leaves the process.\n\nSet on a binary built with `--no-default-features` it fails the boot: that build carries\nno client to install, and starting anyway would be the silent no-op this key exists to\navoid.",
+                "type": "boolean"
+              },
+              "environment": {
+                "description": "Environment tag on every event. Defaults to `production`, or `development` for a debug\nbuild.\n\nAlways sent, never left for the SDK to fill in. `sentry::init` otherwise reads\n`SENTRY_ENVIRONMENT` from the process environment — a second configuration channel that\nbypasses the layered loader, its shadow-key rejection and the contract, whose external\nsurface says this image reads nothing outside the loader's namespace.",
+                "type": "string"
+              },
+              "max_breadcrumbs": {
+                "default": 100,
+                "description": "How many breadcrumbs one event carries.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "release": {
+                "description": "Release tag on every event. Defaults to the version the binary was built from.\n\nSet explicitly for the same reason [`Self::environment`] is, and this is the field that\nmakes a regression attributable to a deploy. The default is what\n`sentry::release_name!` reads out of the build, which is what the image's debug-file\nupload names the symbols under.",
+                "type": "string"
+              },
+              "sample_rate": {
+                "default": 1.0,
+                "description": "Fraction of captured events actually sent, `0.0`–`1.0`.\n\nA blunt volume cap: it drops whole issues rather than repetitions of one, so leave it at\n`1.0` unless a quota forces otherwise.",
+                "type": "number"
+              },
+              "server_name": {
+                "description": "Host tag on every event. Unset, Sentry reports none.\n\nThe hostname of a replica is infrastructure detail, and a pod's is a generated string\nthat changes on every restart, so it is worth a tag only where a deployment has a\nstable name to give it.",
+                "type": "string"
+              },
+              "shutdown_timeout_secs": {
+                "default": 2,
+                "description": "How long process exit waits for queued events to drain.\n\nThe only flush this process performs, and it happens when the guard `main` holds is\ndropped. A container stopped with a short grace period loses whatever is still queued\npast this window.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "traces_sample_rate": {
+                "default": 0.0,
+                "description": "Fraction of traces that are recorded, `0.0`–`1.0`. `0.0` records none.\n\nThis process starts every trace it has — nothing hands it one — so at `0.0` no spans are\nbuilt at all rather than built and dropped by the sampler. `0.05`–`0.2` is an ordinary\nproduction figure; the previous hard-coded value was `0.2`.",
+                "type": "number"
+              }
+            },
+            "type": "object"
           }
         },
         "type": "object"

--- a/justfile
+++ b/justfile
@@ -92,10 +92,17 @@ verify: fmt lint test
 fmt:
     cargo fmt --all
 
+# Both feature sets, because `sentry` is default and `--all-features` therefore never builds the
+# arm that has to compile without it. `src/telemetry/sentry.rs` is written twice, and only the
+# second pass here compiles the second half — along with the tests that pin its one behaviour,
+# refusing `telemetry.sentry.enabled` on a binary with no client to install.
+
 [group('check')]
 lint:
     cargo clippy --all-features --all-targets -- -D warnings
+    cargo clippy --no-default-features --all-targets -- -D warnings
 
 [group('check')]
 test:
     cargo test --all-features
+    cargo test --no-default-features

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,6 +42,7 @@ that changes one without the other.
 #[cfg(feature = "config-schema")]
 pub mod contract;
 mod loader;
+mod sentry;
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::str::FromStr;
@@ -52,6 +53,7 @@ use serde::{Deserialize, Deserializer};
 use tracing::Level;
 
 pub use loader::{ConfigError, explain, terrace};
+pub use sentry::{SentryConfig, SentryLevel};
 
 const DEFAULT_METRIC_IP: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
 const DEFAULT_METRIC_PORT: u16 = 9184;
@@ -217,6 +219,10 @@ impl MetricsConfig {
     feature = "config-schema",
     derive(serde::Serialize, terrace_config::schema::Describe)
 )]
+#[allow(
+    clippy::manual_non_exhaustive,
+    reason = "`sentry_dsn` is a removed key kept to refuse it, not a marker sealing the struct"
+)]
 pub struct TelemetryConfig {
     /// The maximum verbosity that reaches stdout: `TRACE`, `DEBUG`, `INFO`, `WARN` or `ERROR`,
     /// in any case.
@@ -228,23 +234,34 @@ pub struct TelemetryConfig {
         serialize_with = "serialize_level"
     )]
     pub log_level: Level,
-    /// Sentry DSN. Unset disables Sentry entirely.
+    /// Error reporting and performance tracing. Off unless configured; see [`SentryConfig`].
     ///
-    /// A write credential for the project's event stream, wrapped for the reason
-    /// [`DiscordConfig::webhook_url`] is.
-    // Not rustdoc: skipped on the way out for the same reason as `webhook_url`. The key still
-    // reports itself as unset by default, which is all a table can usefully say about an
-    // optional secret.
-    #[serde(skip_serializing)]
-    #[cfg_attr(feature = "config-schema", config(secret))]
-    pub sentry_dsn: Option<SecretString>,
+    /// Nested here rather than beside `metrics` because it is a second sink for the same
+    /// `tracing` stream `log_level` governs, not a second exporter.
+    #[serde(default)]
+    #[cfg_attr(feature = "config-schema", config(nested))]
+    pub sentry: SentryConfig,
+    /// The key `telemetry.sentry.dsn` replaced. Supplying it fails the boot.
+    ///
+    /// A rename that resolved silently would take the deployment's error reporting away in the
+    /// upgrade that renamed the key: the old variable would be ignored, `telemetry.sentry.enabled`
+    /// would default to `false`, and the first anyone heard of it would be an incident nobody got
+    /// an issue for. This field is what turns that into a boot failure naming the replacement.
+    // Not rustdoc: `config(skip)` keeps it out of the contract, the README table and the
+    // generated `config.toml`. A key that exists only to be refused is not part of the
+    // configuration surface a chart is checked against — the error message is where it belongs,
+    // and it reaches the one person who set it.
+    #[serde(skip_serializing, deserialize_with = "refuse_removed_sentry_dsn")]
+    #[cfg_attr(feature = "config-schema", config(skip))]
+    sentry_dsn: (),
 }
 
 impl Default for TelemetryConfig {
     fn default() -> Self {
         Self {
             log_level: DEFAULT_LOG_LEVEL,
-            sentry_dsn: None,
+            sentry: SentryConfig::default(),
+            sentry_dsn: (),
         }
     }
 }
@@ -263,6 +280,29 @@ where
             "invalid log level `{raw}`, expected one of TRACE, DEBUG, INFO, WARN, ERROR"
         ))
     })
+}
+
+/// Refuses the removed `telemetry.sentry_dsn` key, naming what replaced it.
+///
+/// Reached only when some layer supplied the key: `serde` skips a `deserialize_with` hook for an
+/// absent field and takes the value from [`TelemetryConfig::default`] instead, so the cost of
+/// this on every other boot is nothing.
+///
+/// The message states both halves of the migration. A DSN alone no longer switches Sentry on —
+/// `telemetry.sentry.enabled` does — so an operator who moved only the value would land on the
+/// same silent no-op one step later.
+fn refuse_removed_sentry_dsn<'de, D>(deserializer: D) -> Result<(), D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // Consumed rather than ignored: the value is a credential, and reading it into a `String`
+    // to reject it would put it in the error `serde` renders for a type mismatch.
+    serde::de::IgnoredAny::deserialize(deserializer)?;
+    Err(serde::de::Error::custom(
+        "`telemetry.sentry_dsn` was replaced by `telemetry.sentry.dsn`, and a DSN no longer \
+         switches Sentry on by itself: set `telemetry.sentry.enabled` as well, then remove \
+         `telemetry.sentry_dsn`",
+    ))
 }
 
 /// Renders a [`Level`] the way every layer spells it.

--- a/src/config/sentry.rs
+++ b/src/config/sentry.rs
@@ -1,0 +1,238 @@
+//! The `telemetry.sentry` block: error reporting and performance tracing.
+//!
+//! Described unconditionally, and deliberately so. The client behind these keys is behind the
+//! `sentry` feature, but the *keys* are not: a contract that gained and lost rows with a build
+//! flag would stop being one document a chart can be checked against. A build without the
+//! feature reads the same block and refuses to boot on [`SentryConfig::enabled`], which is the
+//! honest answer — see `src/telemetry/sentry.rs`.
+//!
+//! # The doc comments below are documentation output
+//!
+//! As everywhere in [`super`]: the first paragraph of each field is the README table's cell and
+//! is written for an operator setting the value. Anything under it is for whoever reads the
+//! type.
+
+use secrecy::SecretString;
+use serde::Deserialize;
+use tracing::Level;
+
+/// How much of the `tracing` stream one Sentry sink takes.
+///
+/// Ordered by severity, so a threshold names the *least* severe record it accepts: `warn` means
+/// `error` and `warn`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(serde::Serialize, terrace_config::schema::Describe)
+)]
+#[serde(rename_all = "lowercase")]
+pub enum SentryLevel {
+    /// Take nothing.
+    Off,
+    /// `error` only.
+    #[default]
+    Error,
+    /// `error` and `warn`.
+    Warn,
+    /// Down to `info`.
+    Info,
+    /// Down to `debug`.
+    Debug,
+    /// Everything.
+    Trace,
+}
+
+impl SentryLevel {
+    /// The least severe [`Level`] this threshold accepts, or `None` for [`Self::Off`].
+    ///
+    /// What the layer's own level filter is built from, so a record below the threshold is never
+    /// handed to Sentry's layer at all rather than handed over and dropped.
+    #[must_use]
+    pub fn threshold(self) -> Option<Level> {
+        match self {
+            Self::Off => None,
+            Self::Error => Some(Level::ERROR),
+            Self::Warn => Some(Level::WARN),
+            Self::Info => Some(Level::INFO),
+            Self::Debug => Some(Level::DEBUG),
+            Self::Trace => Some(Level::TRACE),
+        }
+    }
+
+    /// Whether a record at `level` is at least as severe as this threshold.
+    ///
+    /// [`Level`] orders `ERROR` lowest, so "at least as severe" is `<=`. Inverting it turns
+    /// `capture_level = "error"` into "capture everything", which is a bill rather than a
+    /// compile error.
+    #[must_use]
+    pub fn accepts(self, level: Level) -> bool {
+        self.threshold().is_some_and(|threshold| level <= threshold)
+    }
+}
+
+/// Sentry error reporting and performance tracing.
+///
+/// Off by default. A DSN is an egress destination for whatever a log line happens to carry, so
+/// switching it on is a decision an operator makes once per deployment rather than one this
+/// crate makes for them. With [`Self::enabled`] set the boot fails without a usable
+/// [`Self::dsn`], instead of installing a reporter that reports nowhere.
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(serde::Serialize, terrace_config::schema::Describe)
+)]
+pub struct SentryConfig {
+    /// Initialise the Sentry client. `false` installs no client, no panic hook and no layer, so
+    /// every other key here is inert and nothing leaves the process.
+    ///
+    /// Set on a binary built with `--no-default-features` it fails the boot: that build carries
+    /// no client to install, and starting anyway would be the silent no-op this key exists to
+    /// avoid.
+    pub enabled: bool,
+    /// Ingest URL, `https://<key>@<host>/<project>`. Required once `enabled` is set.
+    ///
+    /// A write credential for the project's event stream, wrapped for the reason
+    /// [`DiscordConfig::webhook_url`](super::DiscordConfig::webhook_url) is. Empty is treated as
+    /// absent rather than as a malformed URL, because an unfilled chart value and a compose
+    /// pass-through both produce an empty string and neither is a typo in a DSN.
+    // Not rustdoc: skipped on the way out because `SecretString` has no `Serialize` impl. The
+    // key keeps its row and its `secret` flag, which is all a table can usefully say about an
+    // optional credential.
+    #[serde(skip_serializing)]
+    #[cfg_attr(feature = "config-schema", config(secret))]
+    pub dsn: Option<SecretString>,
+    /// Environment tag on every event. Defaults to `production`, or `development` for a debug
+    /// build.
+    ///
+    /// Always sent, never left for the SDK to fill in. `sentry::init` otherwise reads
+    /// `SENTRY_ENVIRONMENT` from the process environment — a second configuration channel that
+    /// bypasses the layered loader, its shadow-key rejection and the contract, whose external
+    /// surface says this image reads nothing outside the loader's namespace.
+    pub environment: Option<String>,
+    /// Release tag on every event. Defaults to the version the binary was built from.
+    ///
+    /// Set explicitly for the same reason [`Self::environment`] is, and this is the field that
+    /// makes a regression attributable to a deploy. The default is what
+    /// `sentry::release_name!` reads out of the build, which is what the image's debug-file
+    /// upload names the symbols under.
+    pub release: Option<String>,
+    /// Host tag on every event. Unset, Sentry reports none.
+    ///
+    /// The hostname of a replica is infrastructure detail, and a pod's is a generated string
+    /// that changes on every restart, so it is worth a tag only where a deployment has a
+    /// stable name to give it.
+    pub server_name: Option<String>,
+    /// Fraction of captured events actually sent, `0.0`–`1.0`.
+    ///
+    /// A blunt volume cap: it drops whole issues rather than repetitions of one, so leave it at
+    /// `1.0` unless a quota forces otherwise.
+    pub sample_rate: f32,
+    /// Fraction of traces that are recorded, `0.0`–`1.0`. `0.0` records none.
+    ///
+    /// This process starts every trace it has — nothing hands it one — so at `0.0` no spans are
+    /// built at all rather than built and dropped by the sampler. `0.05`–`0.2` is an ordinary
+    /// production figure; the previous hard-coded value was `0.2`.
+    pub traces_sample_rate: f32,
+    /// Least severe `tracing` level reported as a Sentry issue: `off`, `error`, `warn`, `info`,
+    /// `debug` or `trace`.
+    #[cfg_attr(feature = "config-schema", config(values))]
+    pub capture_level: SentryLevel,
+    /// Least severe `tracing` level kept as a breadcrumb — the trail attached to the next issue.
+    ///
+    /// Records at or above [`Self::capture_level`] become issues instead. Independent of
+    /// [`log_level`](super::TelemetryConfig::log_level) on purpose: the layer keeps collecting
+    /// the trail however quiet stdout is, so an issue raised from an `ERROR` still arrives with
+    /// the round that led to it attached.
+    #[cfg_attr(feature = "config-schema", config(values))]
+    pub breadcrumb_level: SentryLevel,
+    /// How many breadcrumbs one event carries.
+    pub max_breadcrumbs: usize,
+    /// Attach a stack trace to events that carry none of their own.
+    pub attach_stacktraces: bool,
+    /// How long process exit waits for queued events to drain.
+    ///
+    /// The only flush this process performs, and it happens when the guard `main` holds is
+    /// dropped. A container stopped with a short grace period loses whatever is still queued
+    /// past this window.
+    pub shutdown_timeout_secs: u64,
+    /// Print the SDK's own diagnostics to stderr. For proving a DSN works, not for running.
+    pub debug: bool,
+}
+
+impl Default for SentryConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            dsn: None,
+            environment: None,
+            release: None,
+            server_name: None,
+            sample_rate: 1.0,
+            traces_sample_rate: 0.0,
+            capture_level: SentryLevel::Error,
+            breadcrumb_level: SentryLevel::Info,
+            max_breadcrumbs: 100,
+            attach_stacktraces: true,
+            shutdown_timeout_secs: 2,
+            debug: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SentryConfig, SentryLevel};
+    use tracing::Level;
+
+    /// The inversion that a value assertion cannot catch: every level is "at least as severe as"
+    /// something, and getting the comparison the wrong way round turns the default threshold
+    /// into "capture everything".
+    #[test]
+    fn a_threshold_accepts_only_levels_at_least_as_severe() {
+        assert!(SentryLevel::Error.accepts(Level::ERROR));
+        assert!(!SentryLevel::Error.accepts(Level::WARN));
+        assert!(!SentryLevel::Error.accepts(Level::TRACE));
+
+        assert!(SentryLevel::Info.accepts(Level::ERROR));
+        assert!(SentryLevel::Info.accepts(Level::WARN));
+        assert!(SentryLevel::Info.accepts(Level::INFO));
+        assert!(!SentryLevel::Info.accepts(Level::DEBUG));
+
+        for level in [
+            Level::ERROR,
+            Level::WARN,
+            Level::INFO,
+            Level::DEBUG,
+            Level::TRACE,
+        ] {
+            assert!(!SentryLevel::Off.accepts(level));
+            assert!(SentryLevel::Trace.accepts(level));
+        }
+    }
+
+    #[test]
+    fn off_is_the_one_threshold_with_no_level() {
+        assert_eq!(SentryLevel::Off.threshold(), None);
+        assert_eq!(SentryLevel::Error.threshold(), Some(Level::ERROR));
+        assert_eq!(SentryLevel::Trace.threshold(), Some(Level::TRACE));
+    }
+
+    /// The block a deployment that has never heard of it gets. Every one of these is a value
+    /// that reaches a third party or decides whether anything does, so each is worth pinning
+    /// against a careless edit of the `Default` impl above.
+    #[test]
+    fn the_defaults_report_nothing_anywhere() {
+        let config = SentryConfig::default();
+
+        assert!(!config.enabled);
+        assert!(config.dsn.is_none());
+        assert!(config.environment.is_none());
+        assert!(config.release.is_none());
+        assert!(config.server_name.is_none());
+        assert!((config.sample_rate - 1.0).abs() < f32::EPSILON);
+        assert!(config.traces_sample_rate.abs() < f32::EPSILON);
+        assert_eq!(config.capture_level, SentryLevel::Error);
+        assert_eq!(config.breadcrumb_level, SentryLevel::Info);
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,6 +28,15 @@ pub enum Error {
     Prometheus(#[from] prometheus::Error),
     #[error("Prometheus exporter error")]
     PrometheusExport(#[from] prometheus_exporter::Error),
+    /// `telemetry.sentry` is switched on and unusable: no DSN, a DSN that does not parse, a rate
+    /// outside `0.0..=1.0`, or a binary built without the `sentry` feature. A boot failure rather
+    /// than a warning, because the alternative is a process nobody knows has stopped reporting.
+    #[error("Sentry error: {0}")]
+    Sentry(String),
+    /// A `tracing` subscriber was already installed. Only reachable from a second boot inside one
+    /// process, which is a test harness rather than a deployment.
+    #[error("Tracing error: {0}")]
+    Tracing(String),
     /// An unsuccessful HTTP status, or retries running out.
     #[error("Custom: {0}")]
     Custom(String),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ mod error;
 pub mod feed;
 mod feed_state;
 mod metrics;
+pub mod telemetry;
 
 /// The outcome of anything in this crate that can fail.
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,27 +19,22 @@ extern crate tracing;
 use netcup_offer_bot::FeedChecker;
 use netcup_offer_bot::Result;
 use netcup_offer_bot::config::{self, Config};
-use secrecy::{ExposeSecret, SecretString};
-use sentry::ClientInitGuard;
+use netcup_offer_bot::telemetry;
 use std::net::SocketAddr;
 use tokio::time;
 use tokio_stream::StreamExt;
 use tokio_stream::wrappers::IntervalStream;
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::{Layer, filter};
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let config = Config::load()?;
 
-    setup_tracing(config.telemetry.log_level);
+    // Bound for the whole of `main`: the guard flushes queued Sentry events when it drops, and a
+    // `_` binding would drop it at the end of this statement — before the process has done
+    // anything worth reporting.
+    let _telemetry = telemetry::init(&config.telemetry)?;
 
     log_configuration_layers(config.telemetry.log_level);
-
-    // Bound for the whole of `main`: the guard flushes queued events when it drops, and a `_`
-    // binding would drop it at the end of this statement.
-    let _sentry = setup_sentry(config.telemetry.sentry_dsn.as_ref());
 
     setup_metrics(&config.metrics.socket())?;
 
@@ -51,18 +46,6 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
-}
-
-/// Installs the subscriber: stdout at `level`, Sentry at `DEBUG` and above.
-///
-/// The two filters are independent on purpose. Sentry's layer keeps collecting `DEBUG` events as
-/// breadcrumbs however quiet stdout is, so an issue raised from an `ERROR` still arrives with the
-/// round that led to it attached.
-fn setup_tracing(level: tracing::Level) {
-    tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer().with_filter(filter::LevelFilter::from_level(level)))
-        .with(sentry::integrations::tracing::layer().with_filter(filter::LevelFilter::DEBUG))
-        .init();
 }
 
 /// Reports which layer supplied each configuration key.
@@ -84,27 +67,6 @@ fn log_configuration_layers(level: tracing::Level) {
         Ok(layers) => debug!("Configuration layers:\n{}", layers),
         Err(e) => warn!("Could not explain the configuration layers: {}", e),
     }
-}
-
-/// Initialises Sentry, or returns `None` when no DSN is configured.
-///
-/// The guard has to outlive everything worth reporting: dropping it flushes what is queued, and
-/// that is the only flush this process performs. One transaction in five is sampled, and the
-/// release is whatever `sentry::release_name!` reads out of the build.
-fn setup_sentry(dsn: Option<&SecretString>) -> Option<ClientInitGuard> {
-    let Some(dsn) = dsn else {
-        info!("telemetry.sentry_dsn not set, skipping Sentry setup");
-        return None;
-    };
-
-    let mut options = sentry::ClientOptions::new()
-        .traces_sample_rate(0.2)
-        .attach_stacktrace(true);
-    if let Some(release) = sentry::release_name!() {
-        options = options.release(release);
-    }
-
-    Some(sentry::init((dsn.expose_secret(), options)))
 }
 
 /// Starts the Prometheus exporter on `socket`.

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,87 @@
+//! The subscriber this process logs through, and the Sentry client that shares its record stream.
+//!
+//! One call, [`init`], because the two are one installation: the layer reports onto the client,
+//! and the client has to exist before the subscriber that feeds it. Both are process-global and
+//! installed once, which is why `telemetry.*` is the block a running process cannot be told to
+//! re-read.
+//!
+//! # Two filters, on purpose
+//!
+//! stdout is filtered at [`log_level`](crate::config::TelemetryConfig::log_level) and Sentry at
+//! its own thresholds, and neither governs the other. The layer goes on collecting `INFO`
+//! breadcrumbs however quiet stdout has been told to be, so an issue raised from an `ERROR`
+//! still arrives with the round that led to it attached — which is the whole value of a
+//! breadcrumb trail and would be lost the moment one filter sat above both.
+
+mod sentry;
+
+use std::fmt::{self, Debug, Formatter};
+
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{Layer, filter};
+
+use crate::Result;
+use crate::config::TelemetryConfig;
+use crate::error::Error;
+
+/// Keeps the Sentry client alive, and flushes what it has queued when it drops.
+///
+/// Returned rather than stashed in a static because a static is never dropped: the flush that
+/// gets a shutting-down process's last events out happens here, bounded by
+/// `telemetry.sentry.shutdown_timeout_secs`. Bind it for the lifetime of `main` — `let _ = …`
+/// drops it at the end of the statement and closes the client before the process has done
+/// anything worth reporting.
+#[must_use = "dropping the guard closes the Sentry client and stops reporting"]
+pub struct TelemetryGuard(sentry::Guard);
+
+/// Reports whether a client is installed, and nothing else.
+///
+/// Written by hand because `sentry::ClientInitGuard` has no `Debug` of its own, and because the
+/// one thing worth printing about this type is the answer to "is this process reporting".
+impl Debug for TelemetryGuard {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("TelemetryGuard")
+            .field(&sentry::is_active(&self.0))
+            .finish()
+    }
+}
+
+/// Installs the subscriber, and the Sentry client when one is configured.
+///
+/// Order is load-bearing: the client is installed first, so the SDK's panic hook is in place
+/// before the subscriber is built and so the layer below has something to report onto.
+///
+/// # Errors
+/// Fails if `telemetry.sentry` is switched on but unusable — no DSN, a DSN that does not parse,
+/// a sample rate outside `0.0..=1.0`, or a binary built without the `sentry` feature — and if a
+/// subscriber is already installed. All of them are boot failures rather than warnings: each
+/// one's only other outcome is a process that runs while reporting nothing.
+pub fn init(config: &TelemetryConfig) -> Result<TelemetryGuard> {
+    let guard = sentry::init(&config.sentry)?;
+
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_filter(filter::LevelFilter::from_level(config.log_level)),
+        )
+        .with(sentry::tracing_layer(&config.sentry))
+        .try_init()
+        .map_err(|e| Error::Tracing(e.to_string()))?;
+
+    // After `try_init`, not beside the client: a record emitted before the subscriber exists
+    // goes nowhere, and "is this deployment actually reporting" is the first question asked of
+    // a process that has stopped raising issues.
+    if sentry::is_active(&guard) {
+        info!(
+            traces_sample_rate = config.sentry.traces_sample_rate,
+            capture_level = ?config.sentry.capture_level,
+            breadcrumb_level = ?config.sentry.breadcrumb_level,
+            "Sentry reporting enabled"
+        );
+    } else {
+        info!("telemetry.sentry.enabled is not set, nothing is reported to Sentry");
+    }
+
+    Ok(TelemetryGuard(guard))
+}

--- a/src/telemetry/sentry.rs
+++ b/src/telemetry/sentry.rs
@@ -1,0 +1,362 @@
+//! The Sentry half of [`super::init`], in two arms.
+//!
+//! The crate is behind the `sentry` feature; the `telemetry.sentry` configuration block is not.
+//! What follows is therefore written twice — once against the SDK, once against nothing — so
+//! that [`super::init`] is one piece of code with no `#[cfg]` in it and the two builds differ
+//! only in what they are able to do, not in how they are wired.
+//!
+//! The one behaviour the second arm has to get right is refusing `telemetry.sentry.enabled`.
+//! Starting anyway would be the silent no-op the whole block is arranged to avoid, and it is
+//! the failure mode an operator cannot see: a process that boots, serves and reports nothing
+//! looks exactly like a quiet week.
+//!
+//! The extern crate is always spelled `::sentry`; the bare path is this module.
+
+use crate::Result;
+use crate::config::SentryConfig;
+use crate::error::Error;
+
+// ---------------------------------------------------------------------------------------------
+// With the `sentry` feature: the client, and the layer that feeds it.
+// ---------------------------------------------------------------------------------------------
+
+/// What [`super::TelemetryGuard`] holds: the client's flush-on-drop guard, or nothing.
+#[cfg(feature = "sentry")]
+pub(super) type Guard = Option<::sentry::ClientInitGuard>;
+
+/// Installs the process-wide client, or nothing when the block is switched off.
+///
+/// # Errors
+/// Fails when `enabled` is set without a usable DSN, or with a sample rate outside
+/// `0.0..=1.0`. Both are configuration mistakes whose only other outcome is a process that
+/// reports nowhere.
+#[cfg(feature = "sentry")]
+pub(super) fn init(config: &SentryConfig) -> Result<Guard> {
+    use secrecy::ExposeSecret as _;
+    use std::time::Duration;
+
+    if !config.enabled {
+        return Ok(None);
+    }
+
+    // Empty is absent, not a value. An unfilled chart value and a compose pass-through both
+    // resolve to an empty string, and both have to land on the message below rather than on the
+    // parse error, which would send an operator looking at a URL that is not the problem.
+    let dsn = config
+        .dsn
+        .as_ref()
+        .map(|dsn| dsn.expose_secret().trim())
+        .filter(|dsn| !dsn.is_empty());
+    let Some(dsn) = dsn else {
+        return Err(Error::Sentry(
+            "telemetry.sentry.enabled is set but telemetry.sentry.dsn is empty; nothing would \
+             be reported. Set the DSN, or turn the section off."
+                .to_owned(),
+        ));
+    };
+    // Parsed here rather than through `ClientOptions::dsn`, which panics on a malformed value.
+    // The message deliberately does not quote the DSN: it is a credential, and this reaches the
+    // log stream.
+    let dsn = dsn.parse::<::sentry::types::Dsn>().map_err(|e| {
+        Error::Sentry(format!(
+            "telemetry.sentry.dsn is not a valid Sentry DSN ({e}); expected \
+             https://<key>@<host>/<project>"
+        ))
+    })?;
+
+    check_rate("sample_rate", config.sample_rate)?;
+    check_rate("traces_sample_rate", config.traces_sample_rate)?;
+
+    let environment = config
+        .environment
+        .clone()
+        .unwrap_or_else(|| default_environment().to_owned());
+
+    let mut options = ::sentry::ClientOptions::new()
+        .debug(config.debug)
+        .sample_rate(config.sample_rate)
+        .traces_sample_rate(config.traces_sample_rate)
+        .max_breadcrumbs(config.max_breadcrumbs)
+        .attach_stacktrace(config.attach_stacktraces)
+        .shutdown_timeout(Duration::from_secs(config.shutdown_timeout_secs))
+        .environment(environment)
+        // Marks this crate's own frames as application code, so a stack trace opens on the round
+        // that failed rather than on a tokio internal.
+        .in_app_include(vec!["netcup_offer_bot"]);
+    options.dsn = Some(dsn);
+    if let Some(release) = config
+        .release
+        .clone()
+        .or_else(|| ::sentry::release_name!().map(std::borrow::Cow::into_owned))
+    {
+        options = options.release(release);
+    }
+    if let Some(server_name) = config.server_name.clone() {
+        options = options.server_name(server_name);
+    }
+
+    // Every field `apply_defaults` would otherwise fill from `SENTRY_DSN`, `SENTRY_RELEASE` or
+    // `SENTRY_ENVIRONMENT` is set above, and that is the point rather than thoroughness: those
+    // variables are a second configuration channel that bypasses the layered loader and its
+    // shadow-key rejection, and the config contract this image publishes declares that it reads
+    // nothing outside the loader's namespace. An already-set field is one they cannot reach.
+    Ok(Some(::sentry::init(options)))
+}
+
+/// The `tracing` layer feeding the client, or `None` when nothing would reach it.
+///
+/// Its level filter is the more verbose of the two thresholds, so a record below both is never
+/// handed to the layer at all. `None` when the block is off, and also when both thresholds are
+/// `off`: a layer that ignores everything still costs a callsite check on every record.
+#[cfg(feature = "sentry")]
+pub(super) fn tracing_layer<S>(
+    config: &SentryConfig,
+) -> Option<
+    tracing_subscriber::filter::Filtered<
+        ::sentry::integrations::tracing::SentryLayer<S>,
+        tracing_subscriber::filter::LevelFilter,
+        S,
+    >,
+>
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    use ::sentry::integrations::tracing::{EventFilter, default_span_filter};
+    use tracing_subscriber::Layer as _;
+    use tracing_subscriber::filter::LevelFilter;
+
+    if !config.enabled {
+        return None;
+    }
+    let threshold = layer_threshold(config)?;
+
+    let capture = config.capture_level;
+    let breadcrumb = config.breadcrumb_level;
+    // Nothing hands this process a trace to continue — it polls a feed and posts to a webhook —
+    // so at rate `0.0` there is no inherited sampling decision that building spans anyway could
+    // honour, and the sampler would discard every one of them. A service that *is* handed traces
+    // must not gate span creation like this, or it cuts the trace at itself.
+    let traces = config.traces_sample_rate > 0.0;
+
+    let layer = ::sentry::integrations::tracing::layer()
+        .event_filter(move |metadata| {
+            let level = *metadata.level();
+            if capture.accepts(level) {
+                EventFilter::Event
+            } else if breadcrumb.accepts(level) {
+                EventFilter::Breadcrumb
+            } else {
+                EventFilter::Ignore
+            }
+        })
+        .span_filter(move |metadata| traces && default_span_filter(metadata))
+        .with_filter(LevelFilter::from_level(threshold));
+
+    Some(layer)
+}
+
+/// Whether a client is installed.
+#[cfg(feature = "sentry")]
+pub(super) fn is_active(guard: &Guard) -> bool {
+    guard.is_some()
+}
+
+/// The least severe level either sink accepts, or `None` when neither accepts anything.
+///
+/// [`tracing::Level`] orders `ERROR` lowest, so the more verbose of two thresholds is the
+/// greater — the filter has to be the *looser* of the two, or the stricter sink silently
+/// decides what the other one sees.
+#[cfg(feature = "sentry")]
+fn layer_threshold(config: &SentryConfig) -> Option<tracing::Level> {
+    match (
+        config.capture_level.threshold(),
+        config.breadcrumb_level.threshold(),
+    ) {
+        (Some(capture), Some(breadcrumb)) => Some(capture.max(breadcrumb)),
+        (capture, breadcrumb) => capture.or(breadcrumb),
+    }
+}
+
+/// Refuses a rate outside `0.0..=1.0`.
+///
+/// # Errors
+/// Fails naming the key and the value, because the two rates are the keys most likely to be
+/// typed as a percentage.
+#[cfg(feature = "sentry")]
+fn check_rate(name: &str, rate: f32) -> Result<()> {
+    if (0.0..=1.0).contains(&rate) {
+        Ok(())
+    } else {
+        Err(Error::Sentry(format!(
+            "telemetry.sentry.{name} must be between 0.0 and 1.0, got {rate}"
+        )))
+    }
+}
+
+/// The environment tag a build reports under when the configuration names none.
+#[cfg(feature = "sentry")]
+fn default_environment() -> &'static str {
+    if cfg!(debug_assertions) {
+        "development"
+    } else {
+        "production"
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Without it: the same three names, and a boot failure for the one configuration this build
+// cannot honour.
+// ---------------------------------------------------------------------------------------------
+
+/// Nothing to hold: no client was linked.
+///
+/// A type of its own rather than `()`, so that [`super::init`] binds and moves it exactly as it
+/// does the real guard. `()` makes the binding a unit value and the reference below a reference
+/// to one, both of which clippy is right to object to in code that meant either.
+#[cfg(not(feature = "sentry"))]
+#[derive(Debug)]
+pub(super) struct Guard;
+
+/// Refuses `telemetry.sentry.enabled`, and otherwise does nothing.
+///
+/// # Errors
+/// Fails when the block is switched on, naming the feature and both ways out. A binary that
+/// cannot report has to say so at boot: the deployment asked for error reporting, and the
+/// alternative is that it never learns it did not get any.
+#[cfg(not(feature = "sentry"))]
+pub(super) fn init(config: &SentryConfig) -> Result<Guard> {
+    if config.enabled {
+        return Err(Error::Sentry(
+            "telemetry.sentry.enabled is set, but this binary was built without the `sentry` \
+             feature and carries no client to install. Rebuild with default features, or set \
+             telemetry.sentry.enabled = false."
+                .to_owned(),
+        ));
+    }
+    Ok(Guard)
+}
+
+/// No layer, whatever the configuration says.
+///
+/// [`tracing_subscriber::layer::Identity`] rather than a second shape for [`super::init`] to
+/// compose: `None` of any layer type is a layer that does nothing, so the subscriber is built
+/// the same way in both arms.
+#[cfg(not(feature = "sentry"))]
+pub(super) fn tracing_layer(_config: &SentryConfig) -> Option<tracing_subscriber::layer::Identity> {
+    None
+}
+
+/// Never, in this build.
+#[cfg(not(feature = "sentry"))]
+pub(super) fn is_active(_guard: &Guard) -> bool {
+    false
+}
+
+#[cfg(all(test, feature = "sentry"))]
+mod tests {
+    use super::{check_rate, layer_threshold, tracing_layer};
+    use crate::config::{SentryConfig, SentryLevel};
+    use tracing::Level;
+
+    fn enabled() -> SentryConfig {
+        SentryConfig {
+            enabled: true,
+            ..SentryConfig::default()
+        }
+    }
+
+    /// The filter has to be the looser of the two thresholds. Taking the stricter one lets
+    /// `capture_level = "error"` decide that no `INFO` record is ever kept as a breadcrumb,
+    /// which empties the trail attached to every issue without changing a key anyone set.
+    #[test]
+    fn the_layer_filter_is_the_more_verbose_of_the_two_thresholds() {
+        let config = SentryConfig {
+            capture_level: SentryLevel::Error,
+            breadcrumb_level: SentryLevel::Info,
+            ..enabled()
+        };
+        assert_eq!(layer_threshold(&config), Some(Level::INFO));
+
+        let config = SentryConfig {
+            capture_level: SentryLevel::Warn,
+            breadcrumb_level: SentryLevel::Off,
+            ..enabled()
+        };
+        assert_eq!(layer_threshold(&config), Some(Level::WARN));
+
+        let config = SentryConfig {
+            capture_level: SentryLevel::Off,
+            breadcrumb_level: SentryLevel::Trace,
+            ..enabled()
+        };
+        assert_eq!(layer_threshold(&config), Some(Level::TRACE));
+    }
+
+    /// Both sinks off is not "report at the default level", and it is not a layer that ignores
+    /// everything either — it is no layer.
+    #[test]
+    fn two_off_thresholds_install_no_layer() {
+        let config = SentryConfig {
+            capture_level: SentryLevel::Off,
+            breadcrumb_level: SentryLevel::Off,
+            ..enabled()
+        };
+
+        assert_eq!(layer_threshold(&config), None);
+        assert!(tracing_layer::<tracing_subscriber::Registry>(&config).is_none());
+    }
+
+    /// The disabled path installs no layer at all — not a layer under a filter that happens to
+    /// reject everything, which still runs on every record.
+    #[test]
+    fn the_disabled_block_installs_no_layer() {
+        let config = SentryConfig::default();
+
+        assert!(!config.enabled);
+        assert!(tracing_layer::<tracing_subscriber::Registry>(&config).is_none());
+    }
+
+    #[test]
+    fn a_rate_outside_the_unit_interval_is_refused() {
+        assert!(check_rate("sample_rate", 0.0).is_ok());
+        assert!(check_rate("sample_rate", 1.0).is_ok());
+
+        let error = check_rate("traces_sample_rate", 20.0)
+            .expect_err("a percentage typed as a fraction is refused");
+        let message = error.to_string();
+        assert!(
+            message.contains("traces_sample_rate"),
+            "must name the key: {message}"
+        );
+        assert!(message.contains("20"), "must name the value: {message}");
+    }
+}
+
+/// The half of the disabled arm worth a test: the refusal, and that nothing else fails.
+///
+/// Run by `cargo test --no-default-features`, which is what `just test` adds a second pass for.
+#[cfg(all(test, not(feature = "sentry")))]
+mod tests {
+    use super::init;
+    use crate::config::SentryConfig;
+
+    #[test]
+    fn an_unconfigured_block_boots_a_build_with_no_client() {
+        assert!(init(&SentryConfig::default()).is_ok());
+    }
+
+    #[test]
+    fn enabling_it_without_a_client_is_a_boot_failure() {
+        let config = SentryConfig {
+            enabled: true,
+            ..SentryConfig::default()
+        };
+
+        let error = init(&config).expect_err("this build has no client to install");
+        let message = error.to_string();
+        assert!(
+            message.contains("sentry"),
+            "must name the feature: {message}"
+        );
+    }
+}

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -19,12 +19,15 @@
 use std::net::{IpAddr, SocketAddr};
 use std::time::Duration;
 
-use netcup_offer_bot::config::{self, Config};
+use netcup_offer_bot::config::{self, Config, SentryLevel};
 use secrecy::ExposeSecret;
 use terrace_config::testing::Harness;
 use tracing::Level;
 
 const WEB_HOOK: &str = "https://discord.com/api/webhooks/";
+/// Spelled the way Sentry spells one, so a test that stops asserting the value still fails if the
+/// key stops being read as a DSN.
+const DSN: &str = "https://key@sentry.example/42";
 
 /// The keys, as the loader spells them. Every layer derives its own spelling from these, so a
 /// test names a key once and the harness decides whether that means a variable or a file.
@@ -52,7 +55,14 @@ fn env_supplies_required_keys_and_defaults_fill_the_rest() {
             "127.0.0.1:9184".parse::<SocketAddr>().unwrap()
         );
         assert_eq!(config.telemetry.log_level, Level::INFO);
-        assert!(config.telemetry.sentry_dsn.is_none());
+        // A deployment that says nothing about Sentry gets no client and no egress. The block is
+        // `#[serde(default)]` twice over — once on the field, once on the struct — so a missing
+        // section has to materialise rather than fail the boot of a deployment that has never
+        // heard of it.
+        assert!(!config.telemetry.sentry.enabled);
+        assert!(config.telemetry.sentry.dsn.is_none());
+        assert_eq!(config.telemetry.sentry.capture_level, SentryLevel::Error);
+        assert_eq!(config.telemetry.sentry.breadcrumb_level, SentryLevel::Info);
         Ok(())
     });
 }
@@ -66,7 +76,10 @@ fn env_overrides_every_default() {
         jail.env_key("metrics.ip", "0.0.0.0");
         jail.env_key("metrics.port", 9999);
         jail.env_key("telemetry.log_level", "debug");
-        jail.env_key("telemetry.sentry_dsn", "https://sentry/1");
+        jail.env_key("telemetry.sentry.enabled", true);
+        jail.env_key("telemetry.sentry.dsn", DSN);
+        jail.env_key("telemetry.sentry.traces_sample_rate", "0.25");
+        jail.env_key("telemetry.sentry.capture_level", "warn");
 
         let config: Config = jail.load()?;
         assert_eq!(
@@ -74,10 +87,98 @@ fn env_overrides_every_default() {
             "0.0.0.0:9999".parse::<SocketAddr>().unwrap()
         );
         assert_eq!(config.telemetry.log_level, Level::DEBUG);
+
+        let sentry = &config.telemetry.sentry;
+        assert!(sentry.enabled);
+        assert_eq!(sentry.dsn.as_ref().unwrap().expose_secret(), DSN);
+        assert!((sentry.traces_sample_rate - 0.25).abs() < f32::EPSILON);
+        assert_eq!(sentry.capture_level, SentryLevel::Warn);
+        Ok(())
+    });
+}
+
+/// The DSN as the chart supplies it: a mounted `Secret`, one file per key.
+///
+/// The Sentry keys are two levels deep, which is one level deeper than every other block here,
+/// so this is the assertion that the `__` spelling reaches all the way down — and that a
+/// credential can arrive as a file rather than as a variable `docker inspect` prints.
+#[test]
+fn a_mounted_secret_supplies_the_sentry_dsn() {
+    harness().run(|jail| {
+        jail.env_key(WEBHOOK_KEY, WEB_HOOK);
+        jail.env_key(CHECK_INTERVAL_KEY, 42);
+        jail.env_key("telemetry.sentry.enabled", true);
+        jail.secret_key("telemetry.sentry.dsn", DSN)?;
+
+        let config: Config = jail.load()?;
+        assert!(config.telemetry.sentry.enabled);
         assert_eq!(
-            config.telemetry.sentry_dsn.unwrap().expose_secret(),
-            "https://sentry/1"
+            config
+                .telemetry
+                .sentry
+                .dsn
+                .as_ref()
+                .unwrap()
+                .expose_secret(),
+            DSN
         );
+        Ok(())
+    });
+}
+
+/// The key `telemetry.sentry.dsn` replaced, refused rather than ignored.
+///
+/// Silently ignoring it is what would take a deployment's error reporting away in the upgrade
+/// that renamed the key: the variable stops being read, `telemetry.sentry.enabled` defaults to
+/// `false`, and nothing anywhere says so. The message has to name the replacement, because the
+/// operator reading it is holding the old spelling.
+#[test]
+fn the_removed_sentry_dsn_key_fails_the_load() {
+    harness().run(|jail| {
+        jail.env_key(WEBHOOK_KEY, WEB_HOOK);
+        jail.env_key(CHECK_INTERVAL_KEY, 42);
+        jail.env_key("telemetry.sentry_dsn", DSN);
+
+        let error = jail
+            .load::<Config>()
+            .expect_err("`telemetry.sentry_dsn` no longer exists");
+        let message = error.to_string();
+        assert!(
+            message.contains("telemetry.sentry.dsn"),
+            "must name the replacement: {message}"
+        );
+        assert!(
+            message.contains("telemetry.sentry.enabled"),
+            "must say that a DSN alone no longer switches Sentry on: {message}"
+        );
+        Ok(())
+    });
+}
+
+/// A rate the loader cannot parse fails the boot rather than falling back to the default, which
+/// would be a deployment that thinks it is tracing and is not.
+#[test]
+fn an_unparsable_traces_sample_rate_fails_the_load() {
+    harness().run(|jail| {
+        jail.env_key(WEBHOOK_KEY, WEB_HOOK);
+        jail.env_key(CHECK_INTERVAL_KEY, 42);
+        jail.env_key("telemetry.sentry.traces_sample_rate", "a fifth");
+
+        assert!(jail.load::<Config>().is_err());
+        Ok(())
+    });
+}
+
+/// `off`, `error`, `warn`, `info`, `debug`, `trace` — and nothing else. The error has to name the
+/// set, for the reason the log level's does.
+#[test]
+fn an_unknown_capture_level_fails_the_load() {
+    harness().run(|jail| {
+        jail.env_key(WEBHOOK_KEY, WEB_HOOK);
+        jail.env_key(CHECK_INTERVAL_KEY, 42);
+        jail.env_key("telemetry.sentry.capture_level", "fatal");
+
+        assert!(jail.load::<Config>().is_err());
         Ok(())
     });
 }


### PR DESCRIPTION
## What this is

Sentry was a hard dependency switched on by the presence of one key, with the sample rate, the release and the layer's threshold compiled in. It is now a `telemetry.sentry` block of the layered configuration — the shape [TankoVault](https://github.com/TimSchoenle/TankoVault) uses — and the client itself sits behind a default `sentry` cargo feature.

The crate is already on the latest release, `0.49.1`; no version bump was needed.

## The configuration surface

| Key | Default | |
| --- | --- | --- |
| `telemetry.sentry.enabled` | `false` | installs the client, the panic hook and the layer |
| `telemetry.sentry.dsn` | unset | secret; required once `enabled` is set |
| `telemetry.sentry.environment` | `production` / `development` | |
| `telemetry.sentry.release` | the build's version | |
| `telemetry.sentry.server_name` | unset | |
| `telemetry.sentry.sample_rate` | `1.0` | fraction of captured events sent |
| `telemetry.sentry.traces_sample_rate` | `0.0` | performance tracing |
| `telemetry.sentry.capture_level` | `error` | least severe record that becomes an issue |
| `telemetry.sentry.breadcrumb_level` | `info` | least severe record kept as the trail |
| `telemetry.sentry.max_breadcrumbs` | `100` | |
| `telemetry.sentry.attach_stacktraces` | `true` | |
| `telemetry.sentry.shutdown_timeout_secs` | `2` | the one flush this process performs |
| `telemetry.sentry.debug` | `false` | SDK diagnostics on stderr |

Every one takes all three spellings, so the DSN can arrive as a mounted `Secret` like the webhook does.

## Decisions worth reviewing

- **Refuse rather than no-op.** `enabled` without a usable DSN, a DSN that does not parse, and a rate outside `0.0..=1.0` all fail the boot. A reporter that reports nowhere is the failure nobody sees — the process boots, and a quiet issue stream looks like a quiet week.
- **The feature does not move the configuration surface.** The keys are described, documented and published in the contract whether or not `sentry` is compiled in, so one contract describes every build. A `--no-default-features` binary refuses to boot on `telemetry.sentry.enabled` instead of starting a reporter it has no client for. `src/telemetry/sentry.rs` is written twice for that reason, so `src/telemetry.rs` has no `#[cfg]` in it.
- **The environment tag is now always sent.** `sentry::init` otherwise reads `SENTRY_ENVIRONMENT`, which is a second configuration channel bypassing the loader — and the contract declares this image reads nothing outside the loader's namespace.
- **Tracing does no work at rate `0.0`.** Nothing hands this process a trace, so gating span creation locally cannot cut an inherited one. A service that *is* handed traces must not do this.
- **The two filters stay independent.** stdout follows `telemetry.log_level`, Sentry its own thresholds, so an issue raised from an `ERROR` still arrives with its breadcrumb trail however quiet stdout has been told to be.
- **Subscriber installation moved into the library**, `netcup_offer_bot::telemetry`, where it can be tested.

## Breaking change

`telemetry.sentry_dsn` is replaced by `telemetry.sentry.dsn`, and a DSN alone no longer switches Sentry on. **Supplying the old key fails the boot naming both** rather than being ignored — a rename that resolved silently would take a deployment's error reporting away in the upgrade that renamed it.

A deployment setting `NETCUP_OFFER_BOT_TELEMETRY__SENTRY_DSN` needs:

```bash
NETCUP_OFFER_BOT_TELEMETRY__SENTRY__ENABLED=true
NETCUP_OFFER_BOT_TELEMETRY__SENTRY__DSN=…      # or __DSN_FILE, or a mounted secrets file
```

The previously hard-coded trace sample rate of `0.2` is now `telemetry.sentry.traces_sample_rate` and defaults to `0.0`, so restoring the old behaviour means setting it. **The Helm chart needs the matching values change.**

`feat!` because of that key rename — it bumps the major. Retitle to `feat:` if a config-key removal is not worth a major here.

## Checks

- `just verify` green: `cargo fmt`, clippy over `--all-features` **and** `--no-default-features`, tests over both.
- `just regenerate` rewrote `docs/config.contract.json`; the `Dockerfile` LABEL region is unchanged (the prefix did not move).
- rustdoc with `-D warnings` over all three feature sets.
- `just lint`, `just test` and a new `No Default Features` CI job cover the arm `--all-features` never builds.
- `README.md` and `docs/CONFIGURATION.md` are generated; the templates carry the prose edits and the committed copies were re-rendered by hand so this PR is self-consistent. CI will re-render them anyway.

## Tests added

Config: the block defaults to off, the two-level-deep keys resolve through the environment and through a mounted `Secret`, the removed key is refused naming its replacement, an unparseable rate and an unknown level fail the load. Telemetry: the layer filter is the *looser* of the two thresholds, two `off` thresholds install no layer, a rate outside the unit interval is refused; and on the other arm, that a build with no client refuses `enabled` and boots without it.
