### PR TITLE
deps: drop the unused anyhow dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,7 +1135,6 @@ dependencies = [
 name = "netcup-offer-bot"
 version = "2.1.1"
 dependencies = [
- "anyhow",
  "backtrace",
  "chrono",
  "prometheus 0.14.0",
@@ -1894,24 +1893,12 @@ dependencies = [
  "httpdate",
  "reqwest",
  "rustls",
- "sentry-anyhow",
  "sentry-backtrace",
  "sentry-core",
  "sentry-debug-images",
  "sentry-tracing",
  "tokio",
  "ureq",
-]
-
-[[package]]
-name = "sentry-anyhow"
-version = "0.49.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6265521f1b724f709bc07747ecb01c5289b974cb70b348026df01780280fc136"
-dependencies = [
- "anyhow",
- "sentry-backtrace",
- "sentry-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,10 +41,9 @@ name = "config-contract"
 required-features = ["config-schema"]
 
 [dependencies]
-anyhow = { version = "1.0.100", features = ["backtrace"] }
 thiserror = "2.0.18"
 backtrace = "0.3.76"
-sentry = { version = "0.49.1", default-features = false, features = ["anyhow", "debug-images", "reqwest", "rustls", "backtrace", "tracing"] }
+sentry = { version = "0.49.1", default-features = false, features = ["debug-images", "reqwest", "rustls", "backtrace", "tracing"] }
 chrono = { version = "0.4.43", default-features = false, features = ["clock", "std", "wasmbind", "serde"] }
 rss = { version = "2.0.12", features = ["validation"] }
 reqwest = { version = "0.13.1", default-features = false, features = ["json", "rustls", "stream", "gzip"] }


### PR DESCRIPTION
## What changed

- Removed `anyhow = { version = "1.0.100", features = ["backtrace"] }` from `[dependencies]` in `Cargo.toml`.
- Removed `"anyhow"` from the `sentry` feature list.
- Regenerated `Cargo.lock` (`cargo update --workspace`), which drops `sentry-anyhow v0.49.1`.

## Why

Neither was used. The crate's error type in `src/error.rs` is a `thiserror` enum, and `anyhow` appears nowhere in `src`, `tests`, `examples`, the doctests, or the two `config-schema` generator examples — only in the manifest and in historical Renovate entries in `CHANGELOG.md`. The `sentry` `anyhow` feature exists to convert `anyhow::Error` into a Sentry event, which nothing here does, so it pulled in `sentry-anyhow` for nothing.

## Notes for the reviewer

`anyhow` still appears in `Cargo.lock` as a transitive dependency of `reqwest-middleware` and `reqwest-tracing`. That is expected and unavoidable; the point of this change is that the crate no longer links it directly and no longer carries the `backtrace` feature or the Sentry integration on its behalf.

## Verification

- `just verify` passes: `cargo fmt --all`, `cargo clippy --all-features --all-targets -- -D warnings` clean, all tests green (22 unit, 12 config, 8 contract, 5 webhook, 1 doctest).
- `just verify` only exercises `--all-features`, so the default-feature path (what the container runtime stage builds) was checked separately: `cargo clippy --all-targets -- -D warnings` and `cargo test` both clean.
